### PR TITLE
ui: Add a GTK 4 backend

### DIFF
--- a/include/glib-compat.h
+++ b/include/glib-compat.h
@@ -16,6 +16,7 @@
 #ifndef QEMU_GLIB_COMPAT_H
 #define QEMU_GLIB_COMPAT_H
 
+#ifndef GLIB_VERSION_MIN_REQUIRED
 /* Ask for warnings for anything that was marked deprecated in
  * the defined version, or before. It is a candidate for rewrite.
  */
@@ -25,6 +26,7 @@
  * exist in the defined version. These risk breaking builds
  */
 #define GLIB_VERSION_MAX_ALLOWED GLIB_VERSION_2_56
+#endif
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/include/ui/egl-helpers.h
+++ b/include/ui/egl-helpers.h
@@ -60,6 +60,8 @@ int qemu_egl_init_dpy_mesa(EGLNativeDisplayType dpy, DisplayGLMode mode);
 
 #endif
 
+int qemu_egl_init_dpy_wayland(EGLNativeDisplayType dpy, DisplayGLMode mode);
+
 EGLContext qemu_egl_init_ctx(void);
 bool qemu_egl_has_dmabuf(void);
 

--- a/include/ui/gtk4.h
+++ b/include/ui/gtk4.h
@@ -1,0 +1,109 @@
+/*
+ * GTK 4 UI backend based on the GTK 3 backend implementation
+ *
+ * Copyright Red Hat, Corp. 2023
+ * Copyright IBM, Corp. 2012
+ *
+ * Authors:
+ *  Anthony Liguori     <aliguori@us.ibm.com>
+ *  Bilal Elmoussaoui   <belmous@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UI_GTK4_H
+#define UI_GTK4_H
+
+#include <gtk/gtk.h>
+#include <gdk/gdkkeysyms.h>
+#include <gdk/wayland/gdkwayland.h>
+#include <gdk/x11/gdkx.h>
+
+
+#include "ui/console.h"
+#include "ui/kbd-state.h"
+#include "ui/egl-helpers.h"
+#include "ui/egl-context.h"
+
+#define MAX_VCS 10
+
+extern int nb_vcs;
+
+typedef struct GtkDisplayState GtkDisplayState;
+
+typedef struct VirtualGfxConsole {
+    DisplayGLCtx dgc;
+    DisplayChangeListener dcl;
+    GdkGLContext *context;
+    QKbdState *kbd;
+    DisplaySurface *ds;
+    QemuGLShader *gls;
+    int glupdates;
+    int x, y, w, h;
+    egl_fb guest_fb;
+    egl_fb win_fb;
+    egl_fb cursor_fb;
+    int cursor_x;
+    int cursor_y;
+    bool y0_top;
+    bool scanout_mode;
+    bool has_dmabuf;
+} VirtualGfxConsole;
+
+typedef struct VirtualConsole {
+    GtkDisplayState *s;
+    char *label;
+    GtkWidget *window;
+    GtkWidget *widget;
+    /* Used to remember in which position the page was added to GtkNotebook */
+    int index;
+    VirtualGfxConsole gfx;
+} VirtualConsole;
+
+struct GtkDisplayState {
+    GtkApplication *app;
+    GSimpleActionGroup *actions;
+    GtkWidget *menubar;
+    GtkWidget *window;
+
+    GMenu *vc_menu;
+
+    int nb_vcs;
+    VirtualConsole vc[MAX_VCS];
+
+    GtkWidget *notebook;
+    gboolean last_set;
+    int last_x;
+    int last_y;
+    double grab_x_root;
+    double grab_y_root;
+    VirtualConsole *kbd_owner;
+    VirtualConsole *ptr_owner;
+
+    GdkCursor *null_cursor;
+    Notifier mouse_mode_notifier;
+
+    DisplayOptions *opts;
+};
+
+/* ui/gtk4.c */
+void gd_update_windowsize(VirtualConsole *vc);
+void gd_update_monitor_refresh_rate(VirtualConsole *vc);
+int gd_map_keycode(int scancode);
+void gd_set_ui_size(VirtualConsole *vc, int width, int height);
+
+void gd_ungrab_pointer(GtkDisplayState *s);
+void gd_grab_pointer(VirtualConsole *vc, const char *reason);
+
+#endif /* UI_GTK4_H */

--- a/meson.build
+++ b/meson.build
@@ -1273,6 +1273,26 @@ if not get_option('gtk').auto() or have_system
   endif
 endif
 
+gtk4 = not_found
+vte4 = not_found
+if (not get_option('gtk4').auto() or have_system)
+  if gtk.found()
+    error('Both GTK3 & GTK4 are enabled. Only one can be enabled.')
+  endif
+  gtk4 = dependency('gtk4',
+                    method: 'pkg-config',
+                    required: get_option('gtk4'),
+                    kwargs: static_kwargs)
+  if gtk4.found()
+    if not get_option('vte').auto() or have_system
+      vte4 = dependency('vte-2.91-gtk4',
+                        method: 'pkg-config',
+                        required: get_option('vte'),
+                        kwargs: static_kwargs)
+    endif
+  endif
+endif
+
 x11 = not_found
 if gtkx11.found()
   x11 = dependency('x11', method: 'pkg-config', required: gtkx11.found(),
@@ -1848,6 +1868,8 @@ if glusterfs.found()
 endif
 config_host_data.set('CONFIG_GTK', gtk.found())
 config_host_data.set('CONFIG_VTE', vte.found())
+config_host_data.set('CONFIG_GTK4', gtk4.found())
+config_host_data.set('CONFIG_VTE4', vte4.found())
 config_host_data.set('CONFIG_GTK_CLIPBOARD', have_gtk_clipboard)
 config_host_data.set('CONFIG_LIBATTR', have_old_libattr)
 config_host_data.set('CONFIG_LIBCAP_NG', libcap_ng.found())
@@ -1895,6 +1917,7 @@ config_host_data.set('CONFIG_VNC_JPEG', jpeg.found())
 config_host_data.set('CONFIG_VNC_SASL', sasl.found())
 config_host_data.set('CONFIG_VIRTFS', have_virtfs)
 config_host_data.set('CONFIG_VTE', vte.found())
+config_host_data.set('CONFIG_VTE4', vte4.found())
 config_host_data.set('CONFIG_XKBCOMMON', xkbcommon.found())
 config_host_data.set('CONFIG_KEYUTILS', keyutils.found())
 config_host_data.set('CONFIG_GETTID', has_gettid)
@@ -3638,7 +3661,7 @@ subdir('tools')
 subdir('pc-bios')
 subdir('docs')
 subdir('tests')
-if gtk.found()
+if gtk.found() or gtk4.found()
   subdir('po')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -177,6 +177,8 @@ option('pvrdma', type : 'feature', value : 'auto',
        description: 'Enable PVRDMA support')
 option('gtk', type : 'feature', value : 'auto',
        description: 'GTK+ user interface')
+option('gtk4', type : 'feature', value : 'auto',
+       description: 'GTK 4 user interface')
 option('sdl', type : 'feature', value : 'auto',
        description: 'SDL user interface')
 option('sdl_image', type : 'feature', value : 'auto',

--- a/qapi/ui.json
+++ b/qapi/ui.json
@@ -1211,6 +1211,30 @@
                 '*show-menubar'  : 'bool'  } }
 
 ##
+# @DisplayGTK4:
+#
+# GTK 4 display options.
+#
+# @grab-on-hover: Grab keyboard input on mouse hover.
+# @zoom-to-fit: Zoom guest display to fit into the host window.  When
+#               turned off the host window will be resized instead.
+#               In case the display device can notify the guest on
+#               window resizes (virtio-gpu) this will default to "on",
+#               assuming the guest will resize the display to match
+#               the window size then.  Otherwise it defaults to "off".
+# @show-tabs:   Display the tab bar for switching between the various graphical
+#               interfaces (e.g. VGA and virtual console character devices)
+#               by default.
+# @show-menubar: Display the main window menubar. Defaults to "on".
+#
+# Since: 8.0
+##
+{ 'struct'  : 'DisplayGTK4',
+  'data'    : { '*grab-on-hover' : 'bool',
+                '*zoom-to-fit'   : 'bool',
+                '*show-tabs'     : 'bool',
+                '*show-menubar'  : 'bool'  } }
+##
 # @DisplayEGLHeadless:
 #
 # EGL headless display options.
@@ -1369,6 +1393,7 @@
     { 'name': 'default' },
     { 'name': 'none' },
     { 'name': 'gtk', 'if': 'CONFIG_GTK' },
+    { 'name': 'gtk4', 'if': 'CONFIG_GTK4' },
     { 'name': 'sdl', 'if': 'CONFIG_SDL' },
     { 'name': 'egl-headless',
               'if': { 'all': ['CONFIG_OPENGL', 'CONFIG_GBM'] } },
@@ -1401,6 +1426,7 @@
   'discriminator' : 'type',
   'data'    : {
       'gtk': { 'type': 'DisplayGTK', 'if': 'CONFIG_GTK' },
+      'gtk4': { 'type': 'DisplayGTK4', 'if': 'CONFIG_GTK4' },
       'cocoa': { 'type': 'DisplayCocoa', 'if': 'CONFIG_COCOA' },
       'curses': { 'type': 'DisplayCurses', 'if': 'CONFIG_CURSES' },
       'egl-headless': { 'type': 'DisplayEGLHeadless',

--- a/scripts/meson-buildoptions.sh
+++ b/scripts/meson-buildoptions.sh
@@ -97,6 +97,7 @@ meson_options_help() {
   printf "%s\n" '  glusterfs       Glusterfs block device driver'
   printf "%s\n" '  gnutls          GNUTLS cryptography support'
   printf "%s\n" '  gtk             GTK+ user interface'
+  printf "%s\n" '  gtk4            GTK 4 user interface'
   printf "%s\n" '  gtk-clipboard   clipboard support for the gtk UI (EXPERIMENTAL, MAY HANG)'
   printf "%s\n" '  guest-agent     Build QEMU Guest Agent'
   printf "%s\n" '  guest-agent-msi Build MSI package for the QEMU Guest Agent'
@@ -279,6 +280,8 @@ _meson_option_parse() {
     --disable-gprof) printf "%s" -Dgprof=false ;;
     --enable-gtk) printf "%s" -Dgtk=enabled ;;
     --disable-gtk) printf "%s" -Dgtk=disabled ;;
+    --enable-gtk4) printf "%s" -Dgtk4=enabled ;;
+    --disable-gtk4) printf "%s" -Dgtk4=disabled ;;
     --enable-gtk-clipboard) printf "%s" -Dgtk_clipboard=enabled ;;
     --disable-gtk-clipboard) printf "%s" -Dgtk_clipboard=disabled ;;
     --enable-guest-agent) printf "%s" -Dguest_agent=enabled ;;

--- a/softmmu/vl.c
+++ b/softmmu/vl.c
@@ -1871,8 +1871,13 @@ static void qemu_create_early_backends(void)
 #else
     const bool use_gtk = false;
 #endif
+#if defined(CONFIG_GTK4)
+    const bool use_gtk4 = (dpy.type == DISPLAY_TYPE_GTK4);
+#else
+    const bool use_gtk4 = false;
+#endif
 
-    if (dpy.has_window_close && !use_gtk && !use_sdl) {
+    if (dpy.has_window_close && !use_gtk && !use_gtk4 && !use_sdl) {
         error_report("window-close is only valid for GTK and SDL, "
                      "ignoring option");
     }

--- a/ui/console.c
+++ b/ui/console.c
@@ -1206,6 +1206,8 @@ static void displaychangelistener_display_console(DisplayChangeListener *dcl,
     displaychangelistener_gfx_switch(dcl, con->surface,
                                      con->scanout.kind == SCANOUT_SURFACE);
 
+    info_report("scanout kind %i", con->scanout.kind);
+
     if (con->scanout.kind == SCANOUT_DMABUF &&
         displaychangelistener_has_dmabuf(dcl)) {
         dcl->ops->dpy_gl_scanout_dmabuf(dcl, con->scanout.dmabuf);
@@ -1994,7 +1996,7 @@ void dpy_gl_scanout_texture(QemuConsole *con,
 {
     DisplayState *s = con->ds;
     DisplayChangeListener *dcl;
-
+    info_report("dpy_gl_scanout_texture");
     con->scanout.kind = SCANOUT_TEXTURE;
     con->scanout.texture = (ScanoutTexture) {
         backing_id, backing_y_0_top, backing_width, backing_height,
@@ -2018,6 +2020,7 @@ void dpy_gl_scanout_dmabuf(QemuConsole *con,
 {
     DisplayState *s = con->ds;
     DisplayChangeListener *dcl;
+    info_report("dpy_gl_scanout_dmabuf");
 
     con->scanout.kind = SCANOUT_DMABUF;
     con->scanout.dmabuf = dmabuf;

--- a/ui/console.c
+++ b/ui/console.c
@@ -2618,6 +2618,9 @@ void qemu_display_register(QemuDisplay *ui)
 bool qemu_display_find_default(DisplayOptions *opts)
 {
     static DisplayType prio[] = {
+#if defined(CONFIG_GTK4) 
+        DISPLAY_TYPE_GTK4,
+#endif
 #if defined(CONFIG_GTK)
         DISPLAY_TYPE_GTK,
 #endif

--- a/ui/egl-helpers.c
+++ b/ui/egl-helpers.c
@@ -477,6 +477,11 @@ int qemu_egl_init_dpy_x11(EGLNativeDisplayType dpy, DisplayGLMode mode)
 #endif
 }
 
+int qemu_egl_init_dpy_wayland(EGLNativeDisplayType dpy, DisplayGLMode mode)
+{
+    return qemu_egl_init_dpy(dpy, 0, mode);
+}
+
 int qemu_egl_init_dpy_mesa(EGLNativeDisplayType dpy, DisplayGLMode mode)
 {
 #ifdef EGL_MESA_platform_gbm

--- a/ui/gtk4-gfx-vc.c
+++ b/ui/gtk4-gfx-vc.c
@@ -1,0 +1,964 @@
+/*
+ * GTK 4 UI backend
+ *
+ * Virtual Console widget.
+ *
+ * Copyright Red Hat, Corp. 2023
+ *
+ * Authors:
+ *  Bilal Elmoussaoui   <belmous@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtk/gtk.h>
+
+#include "gtk4-gfx-vc.h"
+
+#include "qemu/osdep.h"
+#include "qemu/main-loop.h"
+
+#include "trace.h"
+#include "ui/console.h"
+#include "ui/egl-helpers.h"
+#include "ui/gtk4.h"
+#include "ui/input.h"
+
+#include "sysemu/sysemu.h"
+
+#define VC_SCALE_STEP   0.25
+#define VC_SCALE_MIN    0.25
+
+static void
+virtual_console_gfx_widget_set_scale(VirtualConsoleGfxWidget *self,
+                                     double scale);
+
+
+static void gtk_gl_area_set_scanout_mode(VirtualConsole *vc, bool scanout)
+{
+    if (vc->gfx.scanout_mode == scanout) {
+        return;
+    }
+
+    vc->gfx.scanout_mode = scanout;
+    if (!vc->gfx.scanout_mode) {
+        egl_fb_destroy(&vc->gfx.guest_fb);
+        if (vc->gfx.ds) {
+            surface_gl_destroy_texture(vc->gfx.dgc.gls, vc->gfx.ds);
+            surface_gl_create_texture(vc->gfx.dgc.gls, vc->gfx.ds);
+        }
+    }
+}
+
+static void gd_cursor_define(DisplayChangeListener *dcl,
+                             QEMUCursor *c)
+{
+    info_report("Calling gd_cursor_define");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+    GBytes *bytes;
+    GdkTexture *texture;
+    GdkCursor *cursor;
+
+    if (!gtk_widget_get_realized(vc->widget)) {
+        return;
+    }
+    bytes = g_bytes_new(c->data, c->height * c->width * 4);
+    texture = gdk_memory_texture_new(c->width, c->height,
+                                     GDK_MEMORY_R8G8B8A8,
+                                     bytes, c->width * 4);
+    cursor = gdk_cursor_new_from_texture(texture, c->hot_x, c->hot_y, NULL);
+    gtk_widget_set_cursor(vc->widget, cursor);
+    g_object_unref(cursor);
+}
+
+static void
+gd_gl_area_scanout_disable(DisplayChangeListener *dcl)
+{
+    info_report("Calling gl_area_scanout_disable");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+
+    gtk_gl_area_set_scanout_mode(vc, false);
+}
+
+static void
+gd_gl_area_scanout_texture(DisplayChangeListener *dcl,
+                           uint32_t backing_id,
+                           bool backing_y_0_top,
+                           uint32_t backing_width,
+                           uint32_t backing_height,
+                           uint32_t x, uint32_t y,
+                           uint32_t w, uint32_t h)
+{
+    info_report("Calling gl_area_scanout_texture");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+
+    vc->gfx.x = x;
+    vc->gfx.y = y;
+    vc->gfx.w = w;
+    vc->gfx.h = h;
+    vc->gfx.y0_top = backing_y_0_top;
+
+
+    if (backing_id == 0 || vc->gfx.w == 0 || vc->gfx.h == 0) {
+        gtk_gl_area_set_scanout_mode(vc, false);
+        return;
+    }
+
+    gtk_gl_area_set_scanout_mode(vc, true);
+    egl_fb_setup_for_tex(&vc->gfx.guest_fb, backing_width, backing_height,
+                         backing_id, false);
+}
+
+static void
+gd_gl_area_scanout_dmabuf(DisplayChangeListener *dcl,
+                          QemuDmaBuf *dmabuf)
+{
+    info_report("Calling gl_area_scanout_dmabuf");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+
+    egl_dmabuf_import_texture(dmabuf);
+    if (!dmabuf->texture) {
+        return;
+    }
+    info_report("Importing texture");
+    gd_gl_area_scanout_texture(dcl, dmabuf->texture,
+                               false, dmabuf->width, dmabuf->height,
+                               0, 0, dmabuf->width, dmabuf->height);
+
+    if (dmabuf->allow_fences) {
+        vc->gfx.guest_fb.dmabuf = dmabuf;
+    }
+}
+
+static void gd_gl_area_scanout_flush(DisplayChangeListener *dcl,
+                              uint32_t x, uint32_t y,
+                              uint32_t w, uint32_t h)
+{
+    info_report("Calling gl_area_scanout_flush");
+}
+
+static
+void gd_dpy_refresh(DisplayChangeListener *dcl)
+{
+    //info_report("gd_dpy_refresh");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+    gd_update_monitor_refresh_rate(vc);
+
+    graphic_hw_update(dcl->con);
+
+    if (vc->gfx.glupdates) {
+        vc->gfx.glupdates = 0;
+        gtk_widget_queue_draw(vc->widget);
+    }
+}
+
+static
+void gd_dpy_gfx_update(DisplayChangeListener *dcl,
+                       int x, int y, int w, int h)
+{
+    //info_report("gd_dpy_gfx_update");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+
+    gdk_gl_context_make_current(vc->gfx.context);
+    surface_gl_update_texture(vc->gfx.dgc.gls, vc->gfx.ds, x, y, w, h);
+    vc->gfx.glupdates++;
+}
+
+static
+void gd_dpy_gfx_switch(DisplayChangeListener *dcl,
+                      struct DisplaySurface *surface)
+{
+    info_report("gd_dpy_gfx_switch");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+    DisplaySurface *old_surface = vc->gfx.ds;
+
+    trace_gd_switch(vc->label, surface_width(surface), surface_height(surface));
+    
+    //gdk_gl_context_make_current(vc->gfx.context);
+    surface_gl_destroy_texture(vc->gfx.gls, vc->gfx.ds);
+    vc->gfx.ds = surface;
+
+    if (is_placeholder(surface) && qemu_console_get_index(dcl->con)) {
+        qemu_gl_fini_shader(vc->gfx.gls);
+        vc->gfx.gls = NULL;
+        return;
+    }
+
+    if (!vc->gfx.gls)  {
+        vc->gfx.gls = qemu_gl_init_shader();
+    }else if (old_surface &&
+               ((surface_width(old_surface)  != surface_width(surface)) ||
+                (surface_height(old_surface) != surface_height(surface)))) {
+        gd_update_windowsize(vc);
+    }
+
+    surface_gl_create_texture(vc->gfx.gls, vc->gfx.ds);
+
+}
+static void gd_mouse_set(DisplayChangeListener *dcl,
+                         int x, int y, int visible)
+{
+    info_report("calling gd_mouse_set");
+    /*
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+    GdkDisplay *dpy;
+    gint x_root, y_root;
+    if (qemu_input_is_absolute()) {
+        return;
+    }
+    dpy = gtk_widget_get_display(vc->widget);
+    gdk_window_get_root_coords(gtk_widget_get_window(vc->widget),
+                                x, y, &x_root, &y_root);
+    gdk_device_warp(gd_get_pointer(dpy),
+                    gtk_widget_get_screen(vc->widget),
+                    x_root, y_root);
+    vc->s->last_x = x;
+    vc->s->last_y = y;
+*/
+
+}
+static void gd_gl_release_dmabuf(DisplayChangeListener *dcl,
+                                 QemuDmaBuf *dmabuf)
+{
+    info_report("calling gd_gl_release_dmabuf");
+    egl_dmabuf_release_texture(dmabuf);
+}
+
+static bool gd_has_dmabuf(DisplayChangeListener *dcl)
+{
+    info_report("calling gd_has_dmabuf");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+
+    return vc->gfx.has_dmabuf;
+}
+
+static const DisplayChangeListenerOps dcl_gl_area_ops = {
+    .dpy_name             = "gtk4-egl",
+    .dpy_refresh = gd_dpy_refresh,
+    .dpy_gfx_update = gd_dpy_gfx_update,
+    .dpy_gfx_switch = gd_dpy_gfx_switch,
+    .dpy_gfx_check_format = console_gl_check_format,
+    .dpy_mouse_set        = gd_mouse_set,
+    .dpy_cursor_define    = gd_cursor_define,
+
+    .dpy_gl_scanout_texture  = gd_gl_area_scanout_texture,
+    .dpy_gl_scanout_disable  = gd_gl_area_scanout_disable,
+    .dpy_gl_update           = gd_gl_area_scanout_flush,
+    .dpy_gl_scanout_dmabuf   = gd_gl_area_scanout_dmabuf,
+    .dpy_gl_release_dmabuf   = gd_gl_release_dmabuf,
+    .dpy_has_dmabuf          = gd_has_dmabuf,
+};
+
+static bool
+gd_gl_area_is_compatible_dcl(DisplayGLCtx *dgc,
+                             DisplayChangeListener *dcl)
+{
+    return dcl->ops == &dcl_gl_area_ops;
+}
+
+/**
+ * Make the GL context as current one.
+ * 
+ * Returns 0 on success.
+ */
+static int 
+gd_gl_area_make_current(DisplayGLCtx *dgc,
+                        QEMUGLContext ctx)
+{
+    VirtualConsole *vc = container_of(dgc, VirtualConsole, gfx.dgc);
+    vc->gfx.context = g_object_ref(ctx);
+
+    gdk_gl_context_make_current(ctx);
+    return 0;
+}
+
+static QEMUGLContext 
+gd_gl_area_create_context(DisplayGLCtx *dgc,
+                          QEMUGLParams *params)
+{
+    info_report("Creating gl context");
+    VirtualConsole *vc = container_of(dgc, VirtualConsole, gfx.dgc);
+    GdkGLContext *ctx;
+    GError *err = NULL;
+
+    GtkNative *native = gtk_widget_get_native(vc->widget);
+    GdkSurface *surface = gtk_native_get_surface(native);
+    ctx = gdk_surface_create_gl_context(surface, &err);
+    if (err) {
+        error_report("Create gdk gl context failed: %s\n", err->message);
+        g_error_free(err);
+        return NULL;
+    }
+    gdk_gl_context_set_required_version(ctx,
+                                        params->major_ver,
+                                        params->minor_ver);
+    gdk_gl_context_set_debug_enabled(ctx, TRUE);
+    gdk_gl_context_set_forward_compatible(ctx, TRUE);
+    //gdk_gl_context_set_allowed_apis(ctx, GDK_GL_API_GL);
+    gdk_gl_context_realize(ctx, &err);
+    if (err) {
+        error_report("Realize gdk gl context failed: %s\n", err->message);
+        g_error_free(err);
+        g_clear_object(&ctx);
+        return NULL;
+    }
+
+    vc->gfx.context = g_object_ref(ctx);
+    trace_gtk4_gd_gl_area_create_context(ctx, params->major_ver, params->minor_ver);
+    return ctx;
+}
+
+static void
+gd_gl_area_destroy_context(DisplayGLCtx *dgc, QEMUGLContext ctx)
+{
+    info_report("Calling destroy_context");
+    VirtualConsole *vc = container_of(dgc, VirtualConsole, gfx.dgc);
+    GdkGLContext *current_ctx = gdk_gl_context_get_current();
+
+    trace_gtk4_gd_gl_area_destroy_context(ctx, current_ctx);
+    if (ctx == current_ctx) {
+        info_report("destroying current ctx");
+        gdk_gl_context_clear_current();
+        if (vc->gfx.context) {
+            g_object_unref(vc->gfx.context);
+            vc->gfx.context = NULL;
+        }
+    }
+    g_clear_object(&ctx);
+}
+
+static const DisplayGLCtxOps gl_area_ctx_ops = {
+    .dpy_gl_ctx_is_compatible_dcl = gd_gl_area_is_compatible_dcl,
+    .dpy_gl_ctx_create       = gd_gl_area_create_context,
+    .dpy_gl_ctx_destroy      = gd_gl_area_destroy_context,
+    .dpy_gl_ctx_make_current = gd_gl_area_make_current,
+};
+
+
+struct _VirtualConsoleGfxWidget {
+    GtkWidget parent_instance;
+
+    double scale;
+    gboolean free_scale;
+
+    VirtualConsole *vc;
+    QemuConsole *con;
+};
+
+enum {
+    PROP_0,
+    
+    PROP_VC,
+    PROP_CON,
+
+    PROP_SCALE,
+    PROP_FREE_SCALE,
+    
+    N_PROPS
+};
+
+static GParamSpec *props[N_PROPS] = { 0 };
+
+G_DEFINE_TYPE(VirtualConsoleGfxWidget, virtual_console_gfx_widget,
+             GTK_TYPE_WIDGET);
+
+/** Helpers **/
+
+static void release_modifiers(VirtualConsole *vc)
+{
+    qkbd_state_lift_all_keys(vc->gfx.kbd);
+}
+
+static gboolean gd_win_grab(GtkWidget *widget, GVariant *args,
+                            void *opaque)
+{
+    VirtualConsole *vc = opaque;
+    fprintf(stderr, "%s: %s\n", __func__, vc->label);
+    if (vc->s->ptr_owner) {
+        gd_ungrab_pointer(vc->s);
+    } else {
+        gd_grab_pointer(vc, "user-request-detached-tab");
+    }
+     /** The action was handled successfully */
+    return TRUE;
+}
+
+/** Event Controllers handlers **/
+
+static void gd_key_event(guint keyval, guint keycode, bool is_press,
+                         VirtualConsole *vc)
+{
+    int qcode;
+
+    if (keyval == GDK_KEY_Pause) {
+        qkbd_state_key_event(vc->gfx.kbd, Q_KEY_CODE_PAUSE,
+                             is_press);
+        return;
+    }
+
+    qcode = gd_map_keycode(keycode);
+
+    trace_gtk4_gd_key_event(vc->label, keycode, qcode,
+                       (is_press) ? "down" : "up");
+
+    qkbd_state_key_event(vc->gfx.kbd, qcode,
+                         is_press);
+}
+
+/**
+ * Scroll event handler.
+ *
+ * @param controller The event controller handler
+ * @param delta_x Delta x
+ * @param delta_y Delta y
+ * @param vc The virutal console
+ * @return gboolean Whether the event was handled or not
+ */
+static gboolean on_scroll(GtkEventController *controller,
+                          double delta_x, double delta_y,
+                          VirtualConsole *vc)
+{
+    GdkEvent *event = gtk_event_controller_get_current_event(controller);
+    GdkScrollDirection direction = gdk_scroll_event_get_direction(event);
+    InputButton btn_vertical;
+    InputButton btn_horizontal;
+    bool has_vertical = false;
+    bool has_horizontal = false;
+
+    switch (direction) {
+    case GDK_SCROLL_UP:
+        btn_vertical = INPUT_BUTTON_WHEEL_UP;
+        has_vertical = true;
+    break;
+    case GDK_SCROLL_DOWN:
+        btn_vertical = INPUT_BUTTON_WHEEL_DOWN;
+        has_vertical = true;
+    break;
+    case GDK_SCROLL_LEFT:
+        btn_horizontal = INPUT_BUTTON_WHEEL_LEFT;
+        has_horizontal = true;
+    break;
+    case GDK_SCROLL_RIGHT:
+        btn_horizontal = INPUT_BUTTON_WHEEL_RIGHT;
+        has_horizontal = true;
+    break;
+    case GDK_SCROLL_SMOOTH:
+        if (delta_y > 0) {
+            btn_vertical = INPUT_BUTTON_WHEEL_DOWN;
+            has_vertical = true;
+        } else if (delta_y < 0) {
+            btn_vertical = INPUT_BUTTON_WHEEL_UP;
+            has_vertical = true;
+        } else if (delta_x > 0) {
+            btn_horizontal = INPUT_BUTTON_WHEEL_RIGHT;
+            has_horizontal = true;
+        } else if (delta_x < 0) {
+            btn_horizontal = INPUT_BUTTON_WHEEL_LEFT;
+            has_horizontal = true;
+        }
+    break;
+    }
+
+    if (has_vertical) {
+        qemu_input_queue_btn(vc->gfx.dcl.con, btn_vertical, true);
+        qemu_input_event_sync();
+        qemu_input_queue_btn(vc->gfx.dcl.con, btn_vertical, false);
+        qemu_input_event_sync();
+    }
+
+    if (has_horizontal) {
+        qemu_input_queue_btn(vc->gfx.dcl.con, btn_horizontal, true);
+        qemu_input_event_sync();
+        qemu_input_queue_btn(vc->gfx.dcl.con, btn_horizontal, false);
+        qemu_input_event_sync();
+    }
+
+    return TRUE;
+}
+
+static void on_focus_leave(GtkEventControllerFocus *controller,
+                           VirtualConsole *vc)
+{
+    release_modifiers(vc);
+}
+
+static void gd_key_event_pressed(GtkEventControllerKey *controller,
+                                 guint keyval, guint keycode,
+                                 GdkModifierType state,
+                                 VirtualConsole *vc)
+{
+    gd_key_event(keyval, keycode, true, vc);
+
+}
+
+static void gd_key_event_released(GtkEventControllerKey *controller,
+                                  guint keyval, guint keycode,
+                                  GdkModifierType state,
+                                  VirtualConsole *vc)
+{
+    gd_key_event(keyval, keycode, false, vc);
+}
+
+static gboolean gd_enter_event(GtkEventControllerMotion *controller,
+                               double x, double y,
+                               VirtualConsole *vc)
+{
+  
+/*   GtkDisplayState *s = vc->s;
+   if (s_action_get_state(s->grab_on_hover_action)) {
+        gd_grab_keyboard(vc, "grab-on-hover");
+    }*/
+    return TRUE;
+}
+
+static void gd_button_event(GtkEventController *controller, gint n_presses,
+                            double x, double y, VirtualConsole *vc)
+{
+    GdkEvent *button = gtk_event_controller_get_current_event(controller);
+    GtkDisplayState *s = vc->s;
+    guint button_nbr = gdk_button_event_get_button(GDK_EVENT(button));
+    InputButton btn;
+
+    /* implicitly grab the input at the first click in the relative mode */
+    if (button_nbr == 1 && n_presses == 1 &&
+        !qemu_input_is_absolute() && s->ptr_owner != vc) {
+        if (!vc->window) {
+            //s_action_set_state(s->grab_action, TRUE);
+        } else {
+            gd_grab_pointer(vc, "relative-mode-click");
+        }
+    }
+
+    switch (button_nbr) {
+    case 1:
+        btn = INPUT_BUTTON_LEFT;
+    break;
+    case 2:
+        btn = INPUT_BUTTON_MIDDLE;
+    break;
+    case 3:
+        btn = INPUT_BUTTON_RIGHT;
+    break;
+    case 8:
+        btn = INPUT_BUTTON_SIDE;
+    break;
+    case 9:
+        btn = INPUT_BUTTON_EXTRA;
+    break;
+    default:
+        return;
+    break;
+    }
+
+    if (n_presses == 2 || n_presses == 3) {
+        return;
+    }
+
+    qemu_input_queue_btn(vc->gfx.dcl.con, btn, n_presses == 1);
+    qemu_input_event_sync();
+}
+
+
+static gboolean gd_leave_event(GtkEventControllerMotion *controller,
+                               double x, double y,
+                               VirtualConsole *vc)
+{
+     /* GtkDisplayState *s = vc->s;
+
+  if (s_action_get_state(s->grab_on_hover_action)) {
+        gd_ungrab_keyboard(s);
+    }*/
+    return TRUE;
+}
+
+static void gd_motion_event(GtkEventControllerMotion *controller,
+                            double pointer_x, double pointer_y,
+                            VirtualConsole *vc)
+{
+    GtkDisplayState *s = vc->s;
+    GtkNative *native;
+    GdkSurface *surface;
+    GtkWidget *widget = vc->widget;
+    VirtualConsoleGfxWidget *self = VIRTUAL_CONSOLE_GFX_WIDGET(widget);
+
+    int x, y;
+    int mx = 0;
+    int my = 0;
+    int fbh, fbw;
+    int ww, wh, ws;
+    if (!vc->gfx.ds) {
+        return;
+    }
+
+    fbw = surface_width(vc->gfx.ds) * self->scale;
+    fbh = surface_height(vc->gfx.ds) * self->scale;
+
+    native = gtk_widget_get_native(widget);
+    surface = gtk_native_get_surface(native);
+    ww = gdk_surface_get_width(surface);
+    wh = gdk_surface_get_height(surface);
+    ws = gdk_surface_get_scale_factor(surface);
+
+    if (ww > fbw) {
+        mx = (ww - fbw) / 2;
+    }
+    if (wh > fbh) {
+        my = (wh - fbh) / 2;
+    }
+
+    x = ((int)pointer_x - mx) / self->scale * ws;
+    y = ((int)pointer_y - my) / self->scale * ws;
+
+    if (qemu_input_is_absolute()) {
+        if (x < 0 || y < 0 ||
+            x >= surface_width(vc->gfx.ds) ||
+            y >= surface_height(vc->gfx.ds)) {
+            return;
+        }
+        qemu_input_queue_abs(vc->gfx.dcl.con, INPUT_AXIS_X, x,
+                             0, surface_width(vc->gfx.ds));
+        qemu_input_queue_abs(vc->gfx.dcl.con, INPUT_AXIS_Y, y,
+                             0, surface_height(vc->gfx.ds));
+        qemu_input_event_sync();
+    } else if (s->last_set && s->ptr_owner == vc) {
+        qemu_input_queue_rel(vc->gfx.dcl.con, INPUT_AXIS_X, x - s->last_x);
+        qemu_input_queue_rel(vc->gfx.dcl.con, INPUT_AXIS_Y, y - s->last_y);
+        qemu_input_event_sync();
+    }
+    s->last_x = x;
+    s->last_y = y;
+    s->last_set = TRUE;
+
+    if (!qemu_input_is_absolute() && s->ptr_owner == vc) {
+        GdkDisplay *dpy = gtk_widget_get_display(widget);
+        GdkMonitor *monitor = gdk_display_get_monitor_at_surface(dpy, surface);
+        GdkRectangle geometry;
+
+        int x = (int)pointer_x;
+        int y = (int)pointer_y;
+
+        gdk_monitor_get_geometry(monitor, &geometry);
+
+        /*
+         * In relative mode check to see if client pointer hit
+         * one of the monitor edges, and if so move it back to the
+         * center of the monitor. This is important because the pointer
+         * in the server doesn't correspond 1-for-1, and so
+         * may still be only half way across the screen. Without
+         * this warp, the server pointer would thus appear to hit
+         * an invisible wall
+         */
+        if (x <= geometry.x || x - geometry.x >= geometry.width - 1 ||
+            y <= geometry.y || y - geometry.y >= geometry.height - 1) {
+            x = geometry.x + geometry.width / 2;
+            y = geometry.y + geometry.height / 2;
+
+            /*
+             * FIXME: replace with X11 spexific API
+             * GdkScreen *screen = gtk_widget_get_screen(vc->widget);
+             * GdkDevice *dev = gdk_event_get_device((GdkEvent *)motion);
+             * gdk_device_warp(dev, screen, x, y);
+             */
+            s->last_set = FALSE;
+            return;
+        }
+    }
+    return;
+}
+
+
+/** Actions **/
+
+static void
+virtual_console_gfx_widget_init(VirtualConsoleGfxWidget *widget)
+{
+}
+
+static void
+virtual_console_gfx_widget_constructed(GObject *object)
+{
+    GtkWidget *widget = GTK_WIDGET(object);
+    VirtualConsoleGfxWidget *self = VIRTUAL_CONSOLE_GFX_WIDGET(object);
+    VirtualConsole *vc = self->vc;
+    vc->widget = widget;
+    vc->gfx.context = gdk_gl_context_get_current();
+
+    gtk_widget_set_hexpand(widget, TRUE);
+    gtk_widget_set_vexpand(widget, TRUE);
+    gtk_widget_set_can_focus(widget, TRUE);
+    gtk_widget_set_focusable(widget, TRUE);
+
+    GtkEventController *key_controller = gtk_event_controller_key_new();
+    gtk_widget_add_controller(widget, key_controller);
+
+    GtkEventController *scroll_controller = gtk_event_controller_scroll_new(
+        GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES
+    );
+    g_signal_connect(scroll_controller, "scroll",
+                    G_CALLBACK(on_scroll), &vc);
+    gtk_widget_add_controller(widget, scroll_controller);
+
+    g_signal_connect(key_controller, "key-pressed",
+                        G_CALLBACK(gd_key_event_pressed), vc);
+    g_signal_connect(key_controller, "key-released",
+                        G_CALLBACK(gd_key_event_released), vc);
+
+    GtkEventController *controller = gtk_event_controller_focus_new();
+    g_signal_connect(controller, "leave",
+                     G_CALLBACK(on_focus_leave), vc);
+    gtk_widget_add_controller(widget, controller);
+
+    GtkGesture *gesture = gtk_gesture_click_new();
+    g_signal_connect(gesture, "pressed",
+                     G_CALLBACK(gd_button_event), vc);
+    g_signal_connect(gesture, "released",
+                     G_CALLBACK(gd_button_event), vc);
+    gtk_widget_add_controller(widget, GTK_EVENT_CONTROLLER(gesture));
+
+    GtkEventController *motion = gtk_event_controller_motion_new();
+    g_signal_connect(motion, "motion",
+                        G_CALLBACK(gd_motion_event), vc);
+    g_signal_connect(motion, "enter",
+                        G_CALLBACK(gd_enter_event), vc);
+    g_signal_connect(motion, "leave",
+                        G_CALLBACK(gd_leave_event), vc);
+    gtk_widget_add_controller(widget, motion);
+
+    vc->gfx.dcl.con = self->con;
+    vc->gfx.has_dmabuf = qemu_egl_has_dmabuf();
+    vc->gfx.kbd = qkbd_state_init(self->con);
+    vc->label = qemu_console_get_label(self->con);
+    vc->gfx.dgc.gls = qemu_gl_init_shader();
+    vc->gfx.dcl.ops = &dcl_gl_area_ops;
+    vc->gfx.dgc.ops = &gl_area_ctx_ops;
+
+    qemu_console_set_display_gl_ctx(self->con, &vc->gfx.dgc);
+    register_displaychangelistener(&vc->gfx.dcl);
+
+    if (qemu_console_is_graphic(self->con)) {
+        GtkEventController *ctrl = gtk_shortcut_controller_new();
+        GdkModifierType modifiers = GDK_CONTROL_MASK | GDK_ALT_MASK;
+        GtkShortcutTrigger *trigger = gtk_keyval_trigger_new(GDK_KEY_g,
+                                                                modifiers);
+        GtkShortcutAction *action = gtk_callback_action_new(gd_win_grab,
+                                                            vc, NULL);
+        gtk_widget_add_controller(widget, ctrl);
+        GtkShortcut *shortcut = gtk_shortcut_new(trigger, action);
+        GtkShortcutController *controller = GTK_SHORTCUT_CONTROLLER(ctrl);
+        gtk_shortcut_controller_add_shortcut(controller, shortcut);
+    }
+    
+
+    G_OBJECT_CLASS(virtual_console_gfx_widget_parent_class)->constructed(object);
+}
+
+static void
+virtual_console_gfx_widget_get_property(GObject    *object,
+                                        guint       prop_id,
+                                        GValue     *value,
+                                        GParamSpec *pspec)
+{
+    VirtualConsoleGfxWidget *self = VIRTUAL_CONSOLE_GFX_WIDGET(object);
+    switch (prop_id) {
+    case PROP_VC:
+        g_value_set_pointer(value, &self->vc);
+    break;
+    case PROP_CON:
+        g_value_set_pointer(value, &self->con);
+    break;
+    case PROP_SCALE:
+        g_value_set_double(value, self->scale);
+    break;
+    case PROP_FREE_SCALE:
+        g_value_set_boolean(value, self->free_scale);
+    break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+}
+
+static void
+virtual_console_gfx_widget_set_property(GObject      *object,
+                                        guint         prop_id,
+                                        const GValue *value,
+                                        GParamSpec   *pspec)
+{
+    VirtualConsoleGfxWidget *self = VIRTUAL_CONSOLE_GFX_WIDGET(object);
+
+    switch (prop_id) {
+    case PROP_VC:
+        self->vc = (VirtualConsole *)g_value_get_pointer(value);
+    break;
+    case PROP_CON:
+        self->con = (QemuConsole *)g_value_get_pointer(value);
+    break;
+    case PROP_SCALE:
+        self->scale = g_value_get_double(value);
+    break;
+    case PROP_FREE_SCALE:
+        self->free_scale = g_value_get_boolean(value);
+    break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+}
+
+static void
+virtual_console_gfx_widget_unmap(GtkWidget *widget)
+{
+    VirtualConsoleGfxWidget *self = VIRTUAL_CONSOLE_GFX_WIDGET(widget);
+
+    release_modifiers(self->vc);
+
+    GTK_WIDGET_CLASS(virtual_console_gfx_widget_parent_class)->unmap(widget);
+}
+
+static void
+virtual_console_gfx_widget_snapshot(GtkWidget *widget, GtkSnapshot *snapshot)
+{
+    VirtualConsoleGfxWidget *self = VIRTUAL_CONSOLE_GFX_WIDGET(widget);
+    VirtualConsole *vc = self->vc;
+    GdkTexture *texture;
+    GdkRGBA bg;
+    gdk_rgba_parse(&bg, "#000");
+
+    int surface_w = surface_width(self->vc->gfx.ds);
+    int surface_h = surface_height(self->vc->gfx.ds);
+    int width = gtk_widget_get_allocated_width(widget);
+    int height = gtk_widget_get_allocated_height(widget);
+
+    int x = MAX(0, (width - surface_w * self->scale) / 2);
+    int y = MAX(0, (height - surface_h * self->scale) / 2);
+
+
+    gtk_snapshot_append_color(snapshot, &bg, &GRAPHENE_RECT_INIT (0, 0, width, height));
+
+    if (!gtk_widget_get_realized(widget) || !vc->gfx.ds ) {
+        return;
+    }
+    GdkGLContext *ctx = gdk_gl_context_get_current();
+
+    texture = gdk_gl_texture_new (ctx, vc->gfx.ds->texture, surface_w, surface_h, NULL, NULL);
+    gtk_snapshot_append_texture(snapshot, texture, &GRAPHENE_RECT_INIT (x, y, surface_w * self->scale, surface_h * self->scale));
+}
+
+static void
+virtual_console_gfx_widget_class_init(VirtualConsoleGfxWidgetClass *class)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS(class);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(class);
+
+    object_class->constructed = virtual_console_gfx_widget_constructed;
+    object_class->get_property = virtual_console_gfx_widget_get_property;
+    object_class->set_property = virtual_console_gfx_widget_set_property;
+
+    widget_class->unmap = virtual_console_gfx_widget_unmap;
+    widget_class->snapshot = virtual_console_gfx_widget_snapshot;
+
+  props[PROP_VC] =
+    g_param_spec_pointer("vc",
+                         "Virtual Console",
+                         "Associated Virtual Console",
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+  props[PROP_CON] =
+    g_param_spec_pointer("con",
+                         "QEmu Console",
+                         "QEmu Console Connection",
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+  props[PROP_SCALE] =
+    g_param_spec_double("scale",
+                         "Scale",
+                         "Scale",
+                         VC_SCALE_MIN, 10.0, 1.0,
+                         G_PARAM_READWRITE |
+                         G_PARAM_STATIC_STRINGS);
+  props[PROP_FREE_SCALE] =
+    g_param_spec_boolean("free-scale",
+                         "Free Scale",
+                         "Lock scale",
+                         FALSE,
+                         G_PARAM_READWRITE |
+                         G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties(object_class, N_PROPS, props);
+
+    gtk_widget_class_set_layout_manager_type(widget_class, GTK_TYPE_BIN_LAYOUT);
+
+}
+
+GtkWidget *virtual_console_gfx_widget_new(VirtualConsole *vc, QemuConsole *con)
+{
+    return g_object_new(VIRTUAL_CONSOLE_GFX_WIDGET_TYPE,
+                          "vc", vc,
+                          "con", con,
+                          NULL);
+}
+
+
+void
+virtual_console_gfx_widget_set_scale(VirtualConsoleGfxWidget *self,
+                                     double scale)
+{
+    g_object_set(self, "scale", scale, NULL);
+    gtk_widget_queue_draw(GTK_WIDGET(self));
+}
+
+void
+virtual_console_gfx_widget_set_free_scale(VirtualConsoleGfxWidget *self,
+                                          gboolean free_scale)
+{
+    g_object_set(self, "free-scale", free_scale, NULL);
+    if (!free_scale) {
+        virtual_console_gfx_widget_set_scale(self, 1.0);
+    }
+}
+
+void
+virtual_console_gfx_widget_get_size(VirtualConsoleGfxWidget *self, int *width, int *height)
+{
+    if (!self->vc->gfx.ds) {
+        return;
+    }
+    if (self->free_scale) {
+        *width  = (int)(surface_width(self->vc->gfx.ds) * VC_SCALE_MIN);
+        *height = (int)(surface_height(self->vc->gfx.ds) * VC_SCALE_MIN);
+    } else {
+        *width  = (int)(surface_width(self->vc->gfx.ds) * self->scale);
+        *height = (int)(surface_height(self->vc->gfx.ds) * self->scale);
+    }
+}
+
+void virtual_console_gfx_widget_zoom_in(VirtualConsoleGfxWidget *self)
+{
+    double scale = self->scale + VC_SCALE_STEP; 
+
+    virtual_console_gfx_widget_set_scale(self, scale);    
+}
+
+void virtual_console_gfx_widget_zoom_out(VirtualConsoleGfxWidget *self) 
+{
+    double scale = self->scale; 
+    
+    scale = MAX(scale - VC_SCALE_STEP, VC_SCALE_MIN);
+
+    virtual_console_gfx_widget_set_scale(self, scale);
+}
+
+void virtual_console_gfx_widget_reset_zoom(VirtualConsoleGfxWidget *self) {
+    virtual_console_gfx_widget_set_scale(self, 1.0);
+}

--- a/ui/gtk4-gfx-vc.h
+++ b/ui/gtk4-gfx-vc.h
@@ -1,0 +1,55 @@
+/*
+ * GTK 4 UI backend
+ *
+ * Virtual Console widget.
+ *
+ * Copyright Red Hat, Corp. 2023
+ *
+ * Authors:
+ *  Bilal Elmoussaoui   <belmous@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef GTK_GFX_VC_H
+#define GTK_GFX_VC_H
+
+#include "qemu/osdep.h"
+#include "qemu/main-loop.h"
+
+#include "trace.h"
+#include "ui/console.h"
+#include "ui/gtk4.h"
+#include "ui/egl-helpers.h"
+
+#include "sysemu/sysemu.h"
+
+
+#define VIRTUAL_CONSOLE_GFX_WIDGET_TYPE (virtual_console_gfx_widget_get_type())
+#define VIRTUAL_CONSOLE_IS_GFX_WIDGET(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), VIRTUAL_CONSOLE_GFX_WIDGET_TYPE))
+
+G_DECLARE_FINAL_TYPE(VirtualConsoleGfxWidget, virtual_console_gfx_widget,
+                     VIRTUAL_CONSOLE_GFX, WIDGET, GtkWidget)
+
+GtkWidget *virtual_console_gfx_widget_new(VirtualConsole *vc, QemuConsole *con);
+void virtual_console_gfx_widget_set_free_scale(VirtualConsoleGfxWidget *self,
+                                               gboolean free_scale);
+
+void virtual_console_gfx_widget_zoom_in(VirtualConsoleGfxWidget *self);
+void virtual_console_gfx_widget_zoom_out(VirtualConsoleGfxWidget *self);
+void virtual_console_gfx_widget_reset_zoom(VirtualConsoleGfxWidget *self);
+
+void
+virtual_console_gfx_widget_get_size(VirtualConsoleGfxWidget *self, int *width, int *height);
+
+#endif

--- a/ui/gtk4-gl-area.c
+++ b/ui/gtk4-gl-area.c
@@ -1,0 +1,192 @@
+/*
+ * GTK 4 UI backend based on the GTK 3 backend implementation
+ * 
+ * GLArea OpenGL code.
+ *
+ * Copyright Red Hat, Corp. 2023
+ * Copyright IBM, Corp. 2012
+ *
+ * Authors:
+ *  Anthony Liguori     <aliguori@us.ibm.com>
+ *  Bilal Elmoussaoui   <belmous@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/main-loop.h"
+
+#include "trace.h"
+
+#include "ui/console.h"
+#include "ui/gtk4.h"
+#include "ui/egl-helpers.h"
+
+#include "sysemu/sysemu.h"
+
+static void gtk_gl_area_set_scanout_mode(VirtualConsole *vc, bool scanout)
+{
+    info_report("Setting scanout mode %i", scanout);
+    if (vc->gfx.scanout_mode == scanout) {
+        return;
+    }
+
+    vc->gfx.scanout_mode = scanout;
+    if (!vc->gfx.scanout_mode) {
+        egl_fb_destroy(&vc->gfx.guest_fb);
+    }
+}
+
+static void gd_hw_gl_flushed(void *vcon)
+{
+    VirtualConsole *vc = vcon;
+    QemuDmaBuf *dmabuf = vc->gfx.guest_fb.dmabuf;
+
+    qemu_set_fd_handler(dmabuf->fence_fd, NULL, NULL, NULL);
+    close(dmabuf->fence_fd);
+    dmabuf->fence_fd = -1;
+    graphic_hw_gl_block(vc->gfx.dcl.con, false);
+}
+/** DisplayState Callbacks (opengl version) **/
+
+void gd_gl_area_refresh(DisplayChangeListener *dcl)
+{
+    info_report("Calling gl_area_refresh");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+    GtkWidget *widget = vc->window ? vc->window : vc->gfx.gl_area;
+
+    gd_update_monitor_refresh_rate(vc, widget);
+
+    graphic_hw_update(dcl->con);
+
+    if (vc->gfx.glupdates) {
+        vc->gfx.glupdates = 0;
+        gtk_gl_area_set_scanout_mode(vc, false);
+        gtk_gl_area_queue_render(GTK_GL_AREA(vc->gfx.gl_area));
+    }
+}
+
+void gd_gl_area_switch(DisplayChangeListener *dcl,
+                       DisplaySurface *surface)
+{
+    info_report("Calling gl_area_switch");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+    bool resized = true;
+
+    trace_gd_switch(vc->label, surface_width(surface), surface_height(surface));
+
+    if (vc->gfx.ds &&
+        surface_width(vc->gfx.ds) == surface_width(surface) &&
+        surface_height(vc->gfx.ds) == surface_height(surface)) {
+        resized = false;
+    }
+
+    if (vc->gfx.gls) {
+        //gtk_gl_area_make_current(GTK_GL_AREA(vc->gfx.drawing_area));
+        surface_gl_destroy_texture(vc->gfx.gls, vc->gfx.ds);
+        surface_gl_create_texture(vc->gfx.gls, surface);
+    }
+    vc->gfx.ds = surface;
+
+
+    if (resized) {
+        gd_update_windowsize(vc);
+    }
+}
+
+void gd_gl_area_scanout_texture(DisplayChangeListener *dcl,
+                                uint32_t backing_id,
+                                bool backing_y_0_top,
+                                uint32_t backing_width,
+                                uint32_t backing_height,
+                                uint32_t x, uint32_t y,
+                                uint32_t w, uint32_t h)
+{
+    info_report("Calling gl_area_scanout_texture");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+
+    vc->gfx.x = x;
+    vc->gfx.y = y;
+    vc->gfx.w = w;
+    vc->gfx.h = h;
+    vc->gfx.y0_top = backing_y_0_top;
+
+    gtk_gl_area_make_current(GTK_GL_AREA(vc->gfx.gl_area));
+
+    if (backing_id == 0 || vc->gfx.w == 0 || vc->gfx.h == 0) {
+        gtk_gl_area_set_scanout_mode(vc, false);
+        return;
+    }
+
+    gtk_gl_area_set_scanout_mode(vc, true);
+    egl_fb_setup_for_tex(&vc->gfx.guest_fb, backing_width, backing_height,
+                         backing_id, false);
+}
+
+void gd_gl_area_scanout_disable(DisplayChangeListener *dcl)
+{
+    info_report("Calling gl_area_scanout_disable");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+
+    gtk_gl_area_set_scanout_mode(vc, false);
+}
+
+void gd_gl_area_scanout_flush(DisplayChangeListener *dcl,
+                              uint32_t x, uint32_t y,
+                              uint32_t w, uint32_t h)
+{
+    info_report("Calling gl_area_scanout_flush");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+
+    if (vc->gfx.guest_fb.dmabuf && !vc->gfx.guest_fb.dmabuf->draw_submitted) {
+        graphic_hw_gl_block(vc->gfx.dcl.con, true);
+        vc->gfx.guest_fb.dmabuf->draw_submitted = true;
+    }
+    gtk_gl_area_queue_render(GTK_GL_AREA(vc->gfx.gl_area));
+}
+
+void gd_gl_area_scanout_dmabuf(DisplayChangeListener *dcl,
+                               QemuDmaBuf *dmabuf)
+{
+    info_report("Calling gl_area_scanout_dmabuf");
+    VirtualConsole *vc = container_of(dcl, VirtualConsole, gfx.dcl);
+
+    gtk_gl_area_make_current(GTK_GL_AREA(vc->gfx.gl_area));
+    egl_dmabuf_import_texture(dmabuf);
+    if (!dmabuf->texture) {
+        return;
+    }
+
+    gd_gl_area_scanout_texture(dcl, dmabuf->texture,
+                               false, dmabuf->width, dmabuf->height,
+                               0, 0, dmabuf->width, dmabuf->height);
+
+    if (dmabuf->allow_fences) {
+        vc->gfx.guest_fb.dmabuf = dmabuf;
+    }
+}
+
+void gtk_gl_area_init(void)
+{
+    info_report("Initializing gl area");
+    display_opengl = 1;
+}
+
+int gd_gl_area_make_current(DisplayGLCtx *dgc,
+                            QEMUGLContext ctx)
+{
+    info_report("Making gl context as current");
+    gdk_gl_context_make_current(ctx);
+    return 0;
+}

--- a/ui/gtk4-vte-vc.c
+++ b/ui/gtk4-vte-vc.c
@@ -1,0 +1,358 @@
+/*
+ * GTK 4 UI backend
+ *
+ * Virtual Console widget.
+ *
+ * Copyright Red Hat, Corp. 2023
+ *
+ * Authors:
+ *  Bilal Elmoussaoui   <belmous@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtk/gtk.h>
+#include <vte/vte.h>
+
+#include "gtk4-vte-vc.h"
+
+#include "qapi/error.h"
+#include "qemu/fifo8.h"
+#include "qemu/main-loop.h"
+#include "qemu/osdep.h"
+
+#include "sysemu/sysemu.h"
+
+#include "ui/console.h"
+#include "ui/egl-helpers.h"
+#include "ui/gtk4.h"
+
+#define VC_TERM_X_MIN     80
+#define VC_TERM_Y_MIN     25
+
+static int vcs_idx;
+int nb_vcs;
+static Chardev *vcs[MAX_VCS];
+
+struct _VirtualConsoleVteWidget {
+    GtkWidget parent_instance;
+    GtkWidget *terminal;
+
+    Chardev *chr;
+    Fifo8 out_fifo;
+    bool echo;
+    VirtualConsole *vc;
+};
+
+enum {
+  PROP_0,
+
+  PROP_VC,
+
+  N_PROPS
+};
+
+static GParamSpec *props[N_PROPS] = { 0 };
+
+G_DEFINE_TYPE(VirtualConsoleVteWidget, virtual_console_vte_widget,
+              GTK_TYPE_WIDGET);
+
+/** Terminal callbacks **/
+
+static void gd_vc_send_chars(VirtualConsoleVteWidget *widget)
+{
+    uint32_t len, avail;
+
+    len = qemu_chr_be_can_write(widget->chr);
+    avail = fifo8_num_used(&widget->out_fifo);
+    while (len > 0 && avail > 0) {
+        const uint8_t *buf;
+        uint32_t size;
+
+        buf = fifo8_pop_buf(&widget->out_fifo, MIN(len, avail), &size);
+        qemu_chr_be_write(widget->chr, buf, size);
+        len = qemu_chr_be_can_write(widget->chr);
+        avail -= size;
+    }
+}
+
+static int gd_vc_chr_write(Chardev *chr, const uint8_t *buf, int len)
+{
+    VCChardev *vcd = VC_CHARDEV(chr);
+    VirtualConsoleVteWidget *widget = vcd->widget;
+
+    vte_terminal_feed(VTE_TERMINAL(widget->terminal), (const char *)buf, len);
+    return len;
+}
+
+static void gd_vc_chr_accept_input(Chardev *chr)
+{
+    VCChardev *vcd = VC_CHARDEV(chr);
+    VirtualConsoleVteWidget *widget = vcd->widget;
+
+    gd_vc_send_chars(widget);
+}
+
+static void gd_vc_chr_set_echo(Chardev *chr, bool echo)
+{
+    VCChardev *vcd = VC_CHARDEV(chr);
+    VirtualConsoleVteWidget *widget = vcd->widget;
+
+    if (widget) {
+        widget->echo = echo;
+    } else {
+        vcd->echo = echo;
+    }
+}
+
+static void gd_vc_open(Chardev *chr,
+                       ChardevBackend *backend,
+                       bool *be_opened,
+                       Error **errp)
+{
+    if (nb_vcs == MAX_VCS) {
+        error_setg(errp, "Maximum number of consoles reached");
+        return;
+    }
+
+    vcs[nb_vcs++] = chr;
+    /*
+     * console/chardev init sometimes completes elsewhere in a 2nd
+     * stage, so defer OPENED events until they are fully initialized
+     */
+    *be_opened = false;
+}
+
+static gboolean gd_vc_in(VteTerminal *terminal, gchar *text, guint size,
+                         VirtualConsoleVteWidget *widget)
+{
+    uint32_t free;
+
+    if (widget->echo) {
+        VteTerminal *term = VTE_TERMINAL(widget->terminal);
+        int i;
+        for (i = 0; i < size; i++) {
+            uint8_t c = text[i];
+            if (c >= 128 || isprint(c)) {
+                /* 8-bit characters are considered printable.  */
+                vte_terminal_feed(term, &text[i], 1);
+            } else if (c == '\r' || c == '\n') {
+                vte_terminal_feed(term, "\r\n", 2);
+            } else {
+                char ctrl[2] = { '^', 0};
+                ctrl[1] = text[i] ^ 64;
+                vte_terminal_feed(term, ctrl, 2);
+            }
+        }
+    }
+
+    free = fifo8_num_free(&widget->out_fifo);
+    fifo8_push_all(&widget->out_fifo, (uint8_t *)text, MIN(free, size));
+    gd_vc_send_chars(widget);
+
+    return TRUE;
+}
+
+/** Event Controllers handlers **/
+
+/**
+ * Keydown event controller handler
+ */
+static gboolean gd_text_key_down(GtkEventControllerKey *controller,
+                                 guint keyval, guint keycode,
+                                 GdkModifierType state,
+                                 VirtualConsole *vc)
+{
+    QemuConsole *con = vc->gfx.dcl.con;
+
+    if (keyval == GDK_KEY_Delete) {
+        kbd_put_qcode_console(con, Q_KEY_CODE_DELETE, false);
+    } else {
+        int qcode = gd_map_keycode(keycode);
+        kbd_put_qcode_console(con, qcode, false);
+    }
+    return TRUE;
+}
+
+
+static void
+virtual_console_vte_widget_init(VirtualConsoleVteWidget *widget)
+{
+}
+
+
+static void
+virtual_console_vte_widget_constructed(GObject *object)
+{
+    char buffer[32];
+    GtkWidget *scrolled_window;
+
+    GtkWidget *widget = GTK_WIDGET(object);
+    VirtualConsoleVteWidget *self = VIRTUAL_CONSOLE_VTE_WIDGET(object);
+    VirtualConsole *vc = self->vc;
+    vc->widget = widget;
+
+    Chardev *chr = vcs[vcs_idx];
+    VCChardev *vcd = VC_CHARDEV(chr);
+
+    self->terminal = vte_terminal_new();
+
+    self->echo = vcd->echo;
+    self->chr = chr;
+    fifo8_create(&self->out_fifo, 4096);
+    vcd->widget = self;
+
+    snprintf(buffer, sizeof(buffer), "vc%d", vcs_idx);
+    vc->label = g_strdup_printf("%s", chr->label ? chr->label : buffer);
+
+    g_signal_connect(self->terminal, "commit", G_CALLBACK(gd_vc_in), self);
+
+    vte_terminal_set_scrollback_lines(VTE_TERMINAL(self->terminal), -1);
+    vte_terminal_set_size(VTE_TERMINAL(self->terminal),
+                          VC_TERM_X_MIN, VC_TERM_Y_MIN);
+    gtk_widget_set_hexpand(widget, TRUE);
+    gtk_widget_set_vexpand(widget, TRUE);
+
+    scrolled_window = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled_window),
+                                  self->terminal);
+    gtk_widget_set_parent(scrolled_window, widget);
+
+    qemu_chr_be_event(chr, CHR_EVENT_OPENED);
+
+    GtkEventController *key_controller = gtk_event_controller_key_new();
+    gtk_widget_add_controller(widget, key_controller);
+
+    g_signal_connect(key_controller, "key-pressed",
+                        G_CALLBACK(gd_text_key_down), vc);
+
+    vcs_idx++;
+    G_OBJECT_CLASS(virtual_console_vte_widget_parent_class)->constructed(object);
+}
+
+static void
+virtual_console_vte_widget_get_property(GObject    *object,
+                                        guint       prop_id,
+                                        GValue     *value,
+                                        GParamSpec *pspec)
+{
+    VirtualConsoleVteWidget *self = VIRTUAL_CONSOLE_VTE_WIDGET(object);
+    switch (prop_id) {
+    case PROP_VC:
+        g_value_set_pointer(value, &self->vc);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+
+}
+
+static void
+virtual_console_vte_widget_set_property(GObject      *object,
+                                        guint         prop_id,
+                                        const GValue *value,
+                                        GParamSpec   *pspec)
+{
+    VirtualConsoleVteWidget *self = VIRTUAL_CONSOLE_VTE_WIDGET(object);
+
+    switch (prop_id) {
+    case PROP_VC:
+        self->vc =  (VirtualConsole *)g_value_get_pointer(value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+}
+
+static gboolean
+virtual_console_vte_widget_grab_focus(GtkWidget *widget)
+{
+    VirtualConsoleVteWidget *self = VIRTUAL_CONSOLE_VTE_WIDGET(widget);
+
+    gtk_widget_grab_focus(self->terminal);
+    return TRUE;
+}
+
+static void
+virtual_console_vte_widget_class_init(VirtualConsoleVteWidgetClass *class)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS(class);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(class);
+
+    object_class->constructed = virtual_console_vte_widget_constructed;
+    object_class->get_property = virtual_console_vte_widget_get_property;
+    object_class->set_property = virtual_console_vte_widget_set_property;
+
+    widget_class->grab_focus = virtual_console_vte_widget_grab_focus;
+
+    props[PROP_VC] =
+    g_param_spec_pointer("vc",
+                         "Virtual Console",
+                         "Associated Virtual Console",
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+
+    g_object_class_install_properties(object_class, N_PROPS, props);
+
+    gtk_widget_class_set_layout_manager_type(widget_class, GTK_TYPE_BIN_LAYOUT);
+}
+
+GtkWidget *virtual_console_vte_widget_new(VirtualConsole *vc)
+{
+    return g_object_new(VIRTUAL_CONSOLE_VTE_WIDGET_TYPE,
+                        "vc", vc,
+                        NULL);
+}
+
+/**
+ * Copy the terminal content to  clipboard.
+ */
+void
+virtual_console_vte_widget_copy(VirtualConsoleVteWidget *self)
+{
+    vte_terminal_copy_clipboard_format(VTE_TERMINAL(self->terminal),
+                                       VTE_FORMAT_TEXT);
+}
+
+void
+virtual_console_vte_widget_get_size(VirtualConsoleVteWidget *self, int *width, int *height)
+{
+    *width = vte_terminal_get_char_width(VTE_TERMINAL(self->terminal)) * VC_TERM_X_MIN;
+    *height = vte_terminal_get_char_height(VTE_TERMINAL(self->terminal)) * VC_TERM_Y_MIN;
+}
+
+
+static void char_gd_vc_class_init(ObjectClass *oc, void *data)
+{
+    ChardevClass *cc = CHARDEV_CLASS(oc);
+
+    cc->parse = qemu_chr_parse_vc;
+    cc->open = gd_vc_open;
+    cc->chr_write = gd_vc_chr_write;
+    cc->chr_accept_input = gd_vc_chr_accept_input;
+    cc->chr_set_echo = gd_vc_chr_set_echo;
+}
+
+static const TypeInfo char_gd_vc_type_info = {
+    .name = TYPE_CHARDEV_VC,
+    .parent = TYPE_CHARDEV,
+    .instance_size = sizeof(VCChardev),
+    .class_init = char_gd_vc_class_init,
+};
+
+void vte_vc_type_register(void)
+{
+    type_register(&char_gd_vc_type_info);
+}

--- a/ui/gtk4-vte-vc.h
+++ b/ui/gtk4-vte-vc.h
@@ -1,0 +1,64 @@
+/*
+ * GTK 4 UI backend
+ *
+ * Virtual Console widget.
+ *
+ * Copyright Red Hat, Corp. 2023
+ *
+ * Authors:
+ *  Bilal Elmoussaoui   <belmous@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef GTK_VTE_VC_H
+#define GTK_VTE_VC_H
+
+#include "qemu/osdep.h"
+#include "qemu/main-loop.h"
+
+#include "trace.h"
+#include "ui/console.h"
+#include "ui/gtk4.h"
+#include "ui/egl-helpers.h"
+#include "chardev/char.h"
+
+#include "sysemu/sysemu.h"
+
+
+#define VIRTUAL_CONSOLE_VTE_WIDGET_TYPE (virtual_console_vte_widget_get_type())
+#define VIRTUAL_CONSOLE_IS_VTE_WIDGET(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), VIRTUAL_CONSOLE_VTE_WIDGET_TYPE))
+
+G_DECLARE_FINAL_TYPE(VirtualConsoleVteWidget, virtual_console_vte_widget,
+                     VIRTUAL_CONSOLE_VTE, WIDGET, GtkWidget)
+
+GtkWidget *virtual_console_vte_widget_new(VirtualConsole *vc);
+void virtual_console_vte_widget_copy(VirtualConsoleVteWidget *self);
+
+void
+virtual_console_vte_widget_get_size(VirtualConsoleVteWidget *self, int *width, int *height);
+
+
+void vte_vc_type_register(void);
+
+struct VCChardev {
+    Chardev parent;
+    VirtualConsoleVteWidget *widget;
+    bool echo;
+};
+typedef struct VCChardev VCChardev;
+
+#define TYPE_CHARDEV_VC "chardev-vc"
+DECLARE_INSTANCE_CHECKER(VCChardev, VC_CHARDEV,
+                         TYPE_CHARDEV_VC)
+#endif

--- a/ui/gtk4.c
+++ b/ui/gtk4.c
@@ -1,0 +1,1248 @@
+/*
+ * GTK 4 UI backend based on the GTK 3 backend implementation
+ * Copyright Red Hat, Corp. 2023
+ * Copyright IBM, Corp. 2012
+ *
+ * Authors:
+ *  Anthony Liguori     <aliguori@us.ibm.com>
+ *  Bilal Elmoussaoui   <belmous@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qemu/osdep.h"
+#include "qapi/error.h"
+#include "qapi/qapi-commands-control.h"
+#include "qapi/qapi-commands-machine.h"
+#include "qapi/qapi-commands-misc.h"
+#include "qemu/cutils.h"
+#include "qemu/main-loop.h"
+
+#include "ui/console.h"
+#include "ui/gtk4.h"
+#include "gtk4-gfx-vc.h"
+
+#include <glib/gi18n.h>
+#include <locale.h>
+#if defined(CONFIG_VTE4)
+#include "gtk4-vte-vc.h"
+#endif
+#include <math.h>
+
+#include "trace.h"
+#include "qemu/cutils.h"
+#include "ui/input.h"
+#include "sysemu/runstate.h"
+#include "sysemu/sysemu.h"
+#include "keymaps.h"
+#include "qom/object.h"
+
+#define VC_WINDOW_X_MIN  320
+#define VC_WINDOW_Y_MIN  240
+
+static const guint16 *keycode_map;
+static size_t keycode_maplen;
+
+static gboolean gtkinit;
+
+static void setup_actions(GtkDisplayState *ds);
+
+
+/** Utility Functions **/
+
+void gd_set_ui_size(VirtualConsole *vc, int width, int height)
+{
+    QemuUIInfo info;
+
+    info = *dpy_get_ui_info(vc->gfx.dcl.con);
+    info.width = width;
+    info.height = height;
+    dpy_set_ui_info(vc->gfx.dcl.con, &info, true);
+}
+
+/**
+ * Find the virtual console by its identifier.
+ *
+ * Return: (nullable): The virtual console.
+ */
+static VirtualConsole *gd_vc_find_by_menu(GtkDisplayState *s, const char* idx)
+{
+    VirtualConsole *vc;
+    gint i;
+
+    for (i = 0; i < s->nb_vcs; i++) {
+        vc = &s->vc[i];
+        if (g_str_equal(vc->label, idx)) {
+            return vc;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * Find the virtual console associated to a specific page.
+ *
+ * Return: (nullable): The virtual console.
+ */
+static VirtualConsole *gd_vc_find_by_page(GtkDisplayState *s, gint page)
+{
+    VirtualConsole *vc;
+    gint i, p;
+
+    for (i = 0; i < s->nb_vcs; i++) {
+        vc = &s->vc[i];
+        p = gtk_notebook_page_num(GTK_NOTEBOOK(s->notebook), vc->widget);
+        if (p == page) {
+            return vc;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * Find the current virtual console of the selected page.
+ *
+ * Return: (nullable): The virtual console.
+ */
+static VirtualConsole *gd_vc_find_current(GtkDisplayState *s)
+{
+    gint page;
+
+    page = gtk_notebook_get_current_page(GTK_NOTEBOOK(s->notebook));
+    if (page == -1) {
+        return NULL;
+    }
+    return gd_vc_find_by_page(s, page);
+}
+
+/**
+ * Retrieve the boolean state of the action.
+ */
+static bool s_action_get_state(GSimpleAction *action)
+{
+    return g_variant_get_boolean(g_action_get_state(G_ACTION(action)));
+}
+
+/**
+ * Set a boolean state of an action
+ */
+static void s_action_set_state(GSimpleAction *action, gboolean state)
+{
+    g_simple_action_set_state(action, g_variant_new_boolean(state));
+}
+
+/**
+ * Update the cursor of a virtual console.
+ */
+static void gd_update_cursor(VirtualConsole *vc)
+{
+    GtkDisplayState *s = vc->s;
+
+    if (!VIRTUAL_CONSOLE_IS_GFX_WIDGET(vc->widget) ||
+        !qemu_console_is_graphic(vc->gfx.dcl.con)) {
+        return;
+    }
+
+    if (!gtk_widget_get_realized(vc->widget)) {
+        return;
+    }
+    gboolean is_fullscreen = gtk_window_is_fullscreen(GTK_WINDOW(s->window));
+
+    if (is_fullscreen || qemu_input_is_absolute() || s->ptr_owner == vc) {
+        gtk_widget_set_cursor(GTK_WIDGET(vc->widget), s->null_cursor);
+    } else {
+        gtk_widget_set_cursor(GTK_WIDGET(vc->widget), NULL);
+    }
+}
+
+/**
+ * Update the window title based on whether the machine is paused / events are grabbed.
+ */
+static void gd_update_caption(GtkDisplayState *s)
+{
+    const char *status = "";
+    gchar *prefix;
+    gchar *title;
+    GAction *pause_action;
+    const char *grab = "";
+    bool is_paused = !runstate_is_running();
+    int i;
+
+    if (qemu_name) {
+        prefix = g_strdup_printf("QEMU (%s)", qemu_name);
+    } else {
+        prefix = g_strdup_printf("QEMU");
+    }
+
+    if (s->ptr_owner != NULL &&
+        s->ptr_owner->window == NULL) {
+        grab = _(" - Press Ctrl+Alt+G to release grab");
+    }
+
+    if (is_paused) {
+        status = _(" [Paused]");
+    }
+    pause_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "pause");
+    s_action_set_state(G_SIMPLE_ACTION(pause_action), is_paused);
+
+    title = g_strdup_printf("%s%s%s", prefix, status, grab);
+    gtk_window_set_title(GTK_WINDOW(s->window), title);
+    g_free(title);
+
+    for (i = 0; i < s->nb_vcs; i++) {
+        VirtualConsole *vc = &s->vc[i];
+
+        if (!vc->window) {
+            continue;
+        }
+        title = g_strdup_printf("%s: %s%s%s", prefix, vc->label,
+                                vc == s->kbd_owner ? " +kbd" : "",
+                                vc == s->ptr_owner ? " +ptr" : "");
+        gtk_window_set_title(GTK_WINDOW(vc->window), title);
+        g_free(title);
+    }
+
+    g_free(prefix);
+}
+
+void gd_update_windowsize(VirtualConsole *vc)
+{
+    GtkDisplayState *s = vc->s;
+    int width = 0;
+    int height = 0;
+    GtkWindow *geo_window = GTK_WINDOW(vc->window ? vc->window : s->window);
+
+    if (VIRTUAL_CONSOLE_IS_GFX_WIDGET(vc->widget)) {
+        virtual_console_gfx_widget_get_size(VIRTUAL_CONSOLE_GFX_WIDGET(vc->widget), 
+                                            &width, &height);
+    } else {
+        virtual_console_vte_widget_get_size(VIRTUAL_CONSOLE_VTE_WIDGET(vc->widget),
+                                            &width, &height);
+    }
+    if (width != 0 && height != 0) {
+        gtk_widget_set_size_request(vc->widget, width, height);
+    }
+    gtk_window_set_default_size(geo_window, VC_WINDOW_X_MIN, VC_WINDOW_Y_MIN);
+}
+
+/** QEMU Events **/
+
+static void
+on_runstate_change_cb(void *opaque, bool running, RunState state)
+{
+    GtkDisplayState *s = opaque;
+
+    gd_update_caption(s);
+}
+
+static void gd_mouse_mode_change(Notifier *notify, void *data)
+{
+    GtkDisplayState *s;
+    GAction *action;
+    int i;
+
+    s = container_of(notify, GtkDisplayState, mouse_mode_notifier);
+    /* release the grab at switching to absolute mode */
+    if (qemu_input_is_absolute() && s->ptr_owner) {
+        if (!s->ptr_owner->window) {
+            action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "grab-input");
+            s_action_set_state(G_SIMPLE_ACTION(action), FALSE);
+        } else {
+            gd_ungrab_pointer(s);
+        }
+    }
+    for (i = 0; i < s->nb_vcs; i++) {
+        VirtualConsole *vc = &s->vc[i];
+        gd_update_cursor(vc);
+    }
+}
+
+
+static void gd_grab_update(VirtualConsole *vc, bool kbd, bool ptr)
+{
+    /*
+     * GdkDisplay *display = gtk_widget_get_display(vc->widget);
+     * GdkSeatCapabilities caps = 0;
+     * GdkCursor *cursor = NULL;
+     * if (kbd) {
+     *     caps |= GDK_SEAT_CAPABILITY_KEYBOARD;
+     * }
+     * if (ptr) {
+     *     caps |= GDK_SEAT_CAPABILITY_ALL_POINTING;
+     *     cursor = vc->s->null_cursor;
+     * }
+     * FIXME: figure out how to replace this with XIGrabDevice
+     * if (caps) {
+     *     gdk_seat_grab(seat, window, caps, false, cursor,
+     *                   NULL, NULL, NULL);
+     * } else {
+     *     gdk_seat_ungrab(seat);
+     * }
+     */
+}
+
+static GdkDevice *gd_get_pointer(GdkDisplay *dpy)
+{
+    return gdk_seat_get_pointer(gdk_display_get_default_seat(dpy));
+}
+
+void gd_ungrab_pointer(GtkDisplayState *s)
+{
+    VirtualConsole *vc = s->ptr_owner;
+
+    if (vc == NULL) {
+        return;
+    }
+    s->ptr_owner = NULL;
+
+    gd_grab_update(vc, vc->s->kbd_owner == vc, false);
+    /*
+     * FIXME: replace with X11 specific APIs maybe?
+     * GdkDisplay *display;
+     * display = gtk_widget_get_display(vc->widget);
+     * gdk_device_warp(gd_get_pointer(display),
+     *                 gtk_widget_get_screen(vc->widget),
+     *                 vc->s->grab_x_root, vc->s->grab_y_root);
+     */
+    gd_update_caption(s);
+    trace_gtk4_gd_ungrab(vc->label, "ptr");
+}
+
+void gd_grab_pointer(VirtualConsole *vc, const char *reason)
+{
+    GdkDisplay *display = gtk_widget_get_display(vc->widget);
+
+    if (vc->s->ptr_owner) {
+        if (vc->s->ptr_owner == vc) {
+            return;
+        } else {
+            gd_ungrab_pointer(vc->s);
+        }
+    }
+
+    gd_grab_update(vc, vc->s->kbd_owner == vc, true);
+    gdk_device_get_surface_at_position(gd_get_pointer(display),
+                                    &vc->s->grab_x_root, &vc->s->grab_y_root);
+    vc->s->ptr_owner = vc;
+    gd_update_caption(vc->s);
+    trace_gtk4_gd_grab(vc->label, "ptr", reason);
+}
+
+static void gd_ungrab_keyboard(GtkDisplayState *s)
+{
+    VirtualConsole *vc = s->kbd_owner;
+
+    if (vc == NULL) {
+        return;
+    }
+    s->kbd_owner = NULL;
+
+    gd_grab_update(vc, false, vc->s->ptr_owner == vc);
+    gd_update_caption(s);
+    trace_gtk4_gd_ungrab(vc->label, "kbd");
+}
+
+static void gd_grab_keyboard(VirtualConsole *vc, const char *reason)
+{
+    if (vc->s->kbd_owner) {
+        if (vc->s->kbd_owner == vc) {
+            return;
+        } else {
+            gd_ungrab_keyboard(vc->s);
+        }
+    }
+
+    gd_grab_update(vc, true, vc->s->ptr_owner == vc);
+    vc->s->kbd_owner = vc;
+    gd_update_caption(vc->s);
+    trace_gtk4_gd_grab(vc->label, "kbd", reason);
+}
+
+/** GTK Events **/
+
+static gboolean gd_window_close(GtkWidget *widget, GtkDisplayState *s)
+{
+    bool allow_close = true;
+
+    if (s->opts->has_window_close && !s->opts->window_close) {
+        allow_close = false;
+    }
+
+    if (allow_close) {
+        qmp_quit(NULL);
+        //g_application_quit(G_APPLICATION(s->app));
+    }
+
+    return TRUE;
+}
+
+void gd_update_monitor_refresh_rate(VirtualConsole *vc)
+{
+    QemuUIInfo info;
+
+    GtkNative *native = gtk_widget_get_native(vc->widget);
+    GdkSurface *surface = gtk_native_get_surface(native);
+    int refresh_rate;
+
+    if (surface) {
+        GdkDisplay *dpy = gtk_widget_get_display(vc->widget);
+        GdkMonitor *monitor = gdk_display_get_monitor_at_surface(dpy, surface);
+        refresh_rate = gdk_monitor_get_refresh_rate(monitor); /* [mHz] */
+    } else {
+        refresh_rate = 0;
+    }
+
+    info = *dpy_get_ui_info(vc->gfx.dcl.con);
+    info.refresh_rate = refresh_rate;
+    dpy_set_ui_info(vc->gfx.dcl.con, &info, true);
+
+    /* T = 1 / f = 1 [s*Hz] / f = 1000*1000 [ms*mHz] / f */
+    vc->gfx.dcl.update_interval = refresh_rate ?
+        MIN(1000 * 1000 / refresh_rate, GUI_REFRESH_INTERVAL_DEFAULT) :
+        GUI_REFRESH_INTERVAL_DEFAULT;
+}
+
+static const guint16 *gd_get_keymap(size_t *maplen)
+{
+    GdkDisplay *dpy = gdk_display_get_default();
+
+    if (GDK_IS_WAYLAND_DISPLAY(dpy)) {
+        trace_gtk4_gd_keymap_windowing("wayland");
+        *maplen = qemu_input_map_xorgevdev_to_qcode_len;
+        return qemu_input_map_xorgevdev_to_qcode;
+    }
+
+    g_warning("Unsupported GDK Windowing platform.\n"
+              "Disabling extended keycode tables.\n"
+              "Please report to qemu-devel@nongnu.org\n"
+              "including the following information:\n"
+              "\n"
+              "  - Operating system\n"
+              "  - GDK Windowing system build\n");
+    return NULL;
+}
+
+int gd_map_keycode(int scancode)
+{
+    if (!keycode_map) {
+        return 0;
+    }
+    if (scancode > keycode_maplen) {
+        return 0;
+    }
+
+    return keycode_map[scancode];
+}
+
+static void gd_change_page(GtkNotebook *nb, gpointer arg1, guint arg2,
+                           GtkDisplayState *s)
+{
+    VirtualConsole *vc;
+    gboolean on_vga;
+    GAction *grab_action;
+    GAction *copy_action;
+    GAction *vc_action;
+    GAction *zoom_to_fit_action;
+    GAction *zoom_in_action;
+    GAction *zoom_out_action;
+    GAction *zoom_fixed_action;
+    GtkWidget *active_window;
+
+    if (!gtk_widget_get_realized(GTK_WIDGET(nb))) {
+        return;
+    }
+
+    vc = gd_vc_find_by_page(s, arg2);
+    if (!vc) {
+        return;
+    }
+    active_window = vc->window ? vc->window : s->window;
+    gboolean is_fullscreen = gtk_window_is_fullscreen(GTK_WINDOW(active_window));
+    gboolean is_gfx = VIRTUAL_CONSOLE_IS_GFX_WIDGET(vc->widget);
+
+    grab_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "grab-input");
+    copy_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "copy");
+    vc_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "vc");
+    zoom_to_fit_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "zoom-fit");
+    zoom_in_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "zoom-in");
+    zoom_out_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "zoom-out");
+    zoom_fixed_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "zoom-fixed");
+
+    on_vga = (is_gfx &&
+              qemu_console_is_graphic(vc->gfx.dcl.con));
+    if (!on_vga) {
+        s_action_set_state(G_SIMPLE_ACTION(grab_action), FALSE);
+    } else if (is_fullscreen) {
+        s_action_set_state(G_SIMPLE_ACTION(grab_action), TRUE);
+    }
+    g_simple_action_set_enabled(G_SIMPLE_ACTION(grab_action), on_vga);
+    g_simple_action_set_enabled(G_SIMPLE_ACTION(copy_action), !is_gfx);
+    g_simple_action_set_enabled(G_SIMPLE_ACTION(zoom_to_fit_action), is_gfx);
+    g_simple_action_set_enabled(G_SIMPLE_ACTION(zoom_in_action), is_gfx);
+    g_simple_action_set_enabled(G_SIMPLE_ACTION(zoom_out_action), is_gfx);
+    g_simple_action_set_enabled(G_SIMPLE_ACTION(zoom_fixed_action), is_gfx);
+
+    g_simple_action_set_state(G_SIMPLE_ACTION(vc_action), g_variant_new_string(vc->label));
+    gd_update_windowsize(vc);
+    gd_update_cursor(vc);
+}
+
+static gboolean
+gd_tab_window_close(GtkWindow *widget, VirtualConsole *vc)
+{
+    GtkDisplayState *s = vc->s;
+
+    g_object_ref(vc->widget);
+    gtk_window_set_child(GTK_WINDOW(vc->window), NULL);
+    gtk_notebook_append_page(GTK_NOTEBOOK(s->notebook), vc->widget, NULL);
+    gtk_notebook_reorder_child(GTK_NOTEBOOK(s->notebook), vc->widget, vc->index);
+    g_object_unref(vc->widget);
+    gtk_notebook_set_tab_label_text(GTK_NOTEBOOK(s->notebook),
+                                    vc->widget, vc->label);
+    /** Put the item back to the menu */
+    const char *action_name = g_strdup_printf("win.vc('%s')", vc->label);
+    g_menu_insert(s->vc_menu, vc->index, vc->label, action_name);
+
+    gtk_window_destroy(GTK_WINDOW(vc->window));
+    vc->window = NULL;
+
+    /** true for stopping other handlers from being invoked for this signal */
+    return TRUE;
+}
+
+/** Window Menu Actions **/
+
+/**
+ * (un)pause the running instance action handler.
+ */
+static void
+on_pause_cb(GSimpleAction *action, GVariant *param, void *user_data)
+{
+    if (runstate_is_running()) {
+        qmp_stop(NULL);
+    } else {
+        qmp_cont(NULL);
+    }
+}
+
+/**
+ * Reset system action handler.
+ */
+static void
+on_reset_cb(GSimpleAction *action, GVariant *param, void *user_data)
+{
+    qmp_system_reset(NULL);
+}
+
+/**
+ * Power down system action handler.
+ */
+static void
+on_powerdown_cb(GSimpleAction *action, GVariant *param, void *user_data)
+{
+    qmp_system_powerdown(NULL);
+}
+
+/**
+ * Quit application action handler.
+ */
+static void
+on_quit_cb(GSimpleAction *action, GVariant *param,
+           void *user_data)
+{   
+    qmp_quit(NULL);
+}
+
+/**
+ * (un)grab input action handler.
+ */
+static void
+on_grab_input_cb(GSimpleAction *action, GVariant *param, void *user_data)
+{
+    GtkDisplayState *s = user_data;
+    VirtualConsole *vc = gd_vc_find_current(s);
+    g_return_if_fail(vc != NULL);
+    
+    if (!s_action_get_state(action)) {
+        s_action_set_state(action, TRUE);
+        gd_grab_keyboard(vc, "user-request-main-window");
+        gd_grab_pointer(vc, "user-request-main-window");
+    } else {
+        s_action_set_state(action, FALSE);
+        gd_ungrab_keyboard(s);
+        gd_ungrab_pointer(s);
+    }
+
+    gd_update_cursor(vc);
+}
+
+
+static void
+on_switch_vc_cb(GSimpleAction *action, GVariant *param,
+                GtkDisplayState *s)
+{
+    VirtualConsole *vc = gd_vc_find_by_menu(s,
+                                            g_variant_get_string(param, NULL));
+    GtkNotebook *nb = GTK_NOTEBOOK(s->notebook);
+    gint page;
+    if (vc) {
+        page = gtk_notebook_page_num(nb, vc->widget);
+        gtk_notebook_set_current_page(nb, page);
+    }
+}
+
+/**
+ * Show/hide tabs action handler.
+ */
+static void
+on_show_tabs_cb(GSimpleAction *action, GVariant *param, void *user_data)
+{
+    GtkDisplayState *s = user_data;
+    VirtualConsole *vc = gd_vc_find_current(s);
+    g_return_if_fail(vc != NULL);
+
+    if (!s_action_get_state(action)) {
+        gtk_notebook_set_show_tabs(GTK_NOTEBOOK(s->notebook), TRUE);
+        s_action_set_state(action, TRUE);
+    } else {
+        gtk_notebook_set_show_tabs(GTK_NOTEBOOK(s->notebook), FALSE);
+        s_action_set_state(action, FALSE);
+    }
+    gd_update_windowsize(vc);
+}
+
+
+/**
+ * Show/hide menu bar action handler.
+ */
+static void
+on_show_menubar_cb(GSimpleAction *action, GVariant *param, void *user_data)
+{
+    GtkDisplayState *s = user_data;
+    VirtualConsole *vc = gd_vc_find_current(s);
+    gboolean is_fullscreen;
+    g_return_if_fail(vc != NULL);
+
+    is_fullscreen = gtk_window_is_fullscreen(GTK_WINDOW(s->window));
+    if (is_fullscreen) {
+        return;
+    }
+
+    if (!s_action_get_state(action)) {
+        s_action_set_state(action, TRUE);
+        gtk_widget_set_visible(s->menubar, TRUE);
+    } else {
+        s_action_set_state(action, FALSE);
+        gtk_widget_set_visible(s->menubar, FALSE);
+    }
+    gd_update_windowsize(vc);
+}
+
+/**
+ * (un)fullscreen action handler.
+ */
+static void
+on_fullscreen_cb(GSimpleAction *action, GVariant* param, void *user_data)
+{
+    GAction *show_tabs_action;
+    GAction *show_menubar_action;
+    gboolean is_fullscreen;
+    GtkDisplayState *s = user_data;
+    VirtualConsole *vc = gd_vc_find_current(s);
+    g_return_if_fail(vc != NULL);
+    
+    show_tabs_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "show-tabs");
+    show_menubar_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "show-menubar");
+    is_fullscreen = gtk_window_is_fullscreen(GTK_WINDOW(s->window));
+
+    if (!is_fullscreen) {
+        gtk_notebook_set_show_tabs(GTK_NOTEBOOK(s->notebook), FALSE);
+        gtk_widget_set_visible(s->menubar, FALSE);
+
+        gtk_window_fullscreen(GTK_WINDOW(s->window));
+    } else {
+        gtk_window_unfullscreen(GTK_WINDOW(s->window));
+        if (s_action_get_state(G_SIMPLE_ACTION(show_tabs_action))) {
+            gtk_notebook_set_show_tabs(GTK_NOTEBOOK(s->notebook), TRUE);
+        }
+        if (s_action_get_state(G_SIMPLE_ACTION(show_menubar_action))) {
+            gtk_widget_set_visible(s->menubar, TRUE);
+        }
+        if (VIRTUAL_CONSOLE_IS_GFX_WIDGET(vc->widget)) {
+            virtual_console_gfx_widget_reset_zoom(
+                VIRTUAL_CONSOLE_GFX_WIDGET(vc->widget)
+            );
+            gd_update_windowsize(vc);
+        }
+    }
+
+    gd_update_cursor(vc);
+}
+
+static void 
+on_copy_cb(GSimpleAction *action, GVariant* param, void *user_data)
+{
+    GtkDisplayState *s = user_data;
+    VirtualConsole *vc = gd_vc_find_current(s);
+
+    g_return_if_fail(vc != NULL);
+    g_return_if_fail(VIRTUAL_CONSOLE_IS_VTE_WIDGET(vc->widget));
+
+    virtual_console_vte_widget_copy(VIRTUAL_CONSOLE_VTE_WIDGET(vc->widget));
+}
+
+/**
+ * Zoom to fit action handler.
+ */
+static void 
+on_zoom_fit_cb(GSimpleAction *action, GVariant* param,
+               void *user_data)
+{
+    GtkDisplayState *s = user_data;
+    VirtualConsole *vc = gd_vc_find_current(s);
+    g_return_if_fail(vc != NULL);
+
+    if (VIRTUAL_CONSOLE_IS_GFX_WIDGET(vc->widget))
+    {
+        VirtualConsoleGfxWidget *widget = VIRTUAL_CONSOLE_GFX_WIDGET(vc->widget);
+        if (s_action_get_state(action)) {
+            s_action_set_state(action, FALSE);
+            virtual_console_gfx_widget_set_free_scale(widget, TRUE);
+        } else {
+            s_action_set_state(action, TRUE);
+            virtual_console_gfx_widget_set_free_scale(widget, FALSE);
+        }
+        gd_update_windowsize(vc);
+    }
+}
+/**
+ * Zoom out action handler.
+ */
+static void
+on_zoom_out_cb(GSimpleAction *action, GVariant* param,
+               void *user_data)
+{
+    GtkDisplayState *s = user_data;
+    GAction *zoom_fit_action;
+    VirtualConsole *vc = gd_vc_find_current(s);
+    g_return_if_fail(vc != NULL);
+
+    VirtualConsoleGfxWidget *widget = VIRTUAL_CONSOLE_GFX_WIDGET(vc->widget);
+    virtual_console_gfx_widget_zoom_out(widget);
+
+    zoom_fit_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "zoom-fit");
+    s_action_set_state(G_SIMPLE_ACTION(zoom_fit_action), FALSE);
+    gd_update_windowsize(vc);
+}
+
+/**
+ * Zoom in action handler.
+ */
+static void
+on_zoom_in_cb(GSimpleAction *action, GVariant* param,
+              void *user_data)
+{
+    GtkDisplayState *s = user_data;
+    GAction *zoom_fit_action;
+    VirtualConsole *vc = gd_vc_find_current(s);
+    g_return_if_fail(vc != NULL);
+
+    VirtualConsoleGfxWidget *widget = VIRTUAL_CONSOLE_GFX_WIDGET(vc->widget);
+    virtual_console_gfx_widget_zoom_in(widget);
+
+    zoom_fit_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "zoom-fit");
+    s_action_set_state(G_SIMPLE_ACTION(zoom_fit_action), FALSE);
+
+    gd_update_windowsize(vc);
+}
+
+/**
+ * Fixed zoom action handler.
+ */
+static void
+on_zoom_fixed_cb(GSimpleAction *action, GVariant* param,
+                 void *user_data)
+{
+    GtkDisplayState *s = user_data;
+    VirtualConsole *vc = gd_vc_find_current(s);
+    g_return_if_fail(vc != NULL);
+
+    VirtualConsoleGfxWidget *widget = VIRTUAL_CONSOLE_GFX_WIDGET(vc->widget);
+    virtual_console_gfx_widget_reset_zoom(widget);
+
+    gd_update_windowsize(vc);
+}
+
+/**
+ * Untabify action handler.
+ */
+static void
+on_untabify_cb(GSimpleAction *action, GVariant *param, void *user_data)
+{
+    GAction *grab_action;
+    GtkDisplayState *s = user_data;
+    VirtualConsole *vc = gd_vc_find_current(s);
+    g_return_if_fail(vc != NULL);
+    g_return_if_fail(vc->window == NULL);
+
+    if (VIRTUAL_CONSOLE_IS_GFX_WIDGET(vc->widget) &&
+        qemu_console_is_graphic(vc->gfx.dcl.con)) {
+        grab_action = g_action_map_lookup_action(G_ACTION_MAP(s->actions), "grab-input");
+        s_action_set_state(G_SIMPLE_ACTION(grab_action), FALSE);
+    }
+
+    vc->window = gtk_window_new();
+    gtk_window_set_default_size(GTK_WINDOW(vc->window), 720, 360);
+    gtk_widget_set_visible(s->menubar, FALSE);
+    gtk_window_set_focus(GTK_WINDOW(vc->window), vc->widget);
+    g_object_ref(vc->widget);
+    gtk_notebook_detach_tab(GTK_NOTEBOOK(s->notebook), vc->widget);
+    gtk_window_set_child(GTK_WINDOW(vc->window), vc->widget);
+    g_object_unref(vc->widget);
+
+    g_menu_remove(s->vc_menu, vc->index);
+
+    g_signal_connect(vc->window, "close-request",
+                        G_CALLBACK(gd_tab_window_close), vc);
+    gtk_window_present(GTK_WINDOW(vc->window));
+
+    gd_update_caption(s);
+}
+
+/** Virtual Console Callbacks **/
+
+static void
+gd_vc_widget_init(GtkDisplayState *s, VirtualConsole *vc)
+{
+    gtk_notebook_append_page(GTK_NOTEBOOK(s->notebook),
+                            vc->widget, gtk_label_new(vc->label));
+    const char *action_name = g_strdup_printf("win.vc('%s')", vc->label);
+    g_menu_append(s->vc_menu, vc->label, action_name);
+    const char *accels[2] = { g_strdup_printf("<Ctrl><Alt>%d", vc->index + 1),
+                              NULL };
+    //gtk_application_set_accels_for_action(s->app, action_name, accels);
+}
+
+/** Window Creation **/
+
+/**
+ * Create a machine menu.
+ */
+static GMenu *
+gd_create_menu_machine(GtkDisplayState *s)
+{
+    GMenu *machine_menu, *model;
+    GMenuItem *section;
+    machine_menu = g_menu_new();
+    g_menu_append(machine_menu, _("_Pause"), "win.pause");
+
+    model = g_menu_new();
+    section = g_menu_item_new_section(NULL,
+                                      G_MENU_MODEL(model));
+    g_menu_append_item(machine_menu, section);
+
+    g_menu_append(model, _("_Reset"), "win.reset");
+    g_menu_append(model, _("Power _Down"), "win.power_down");
+
+    model = g_menu_new();
+    section = g_menu_item_new_section(NULL,
+                                      G_MENU_MODEL(model));
+    g_menu_append_item(machine_menu, section);
+
+    g_menu_append(model, _("_Quit"), "win.quit");
+
+    return machine_menu;
+}
+
+/**
+ * Create a view menu.
+ */
+static GMenu *
+gd_create_menu_view(GtkDisplayState *s, DisplayOptions *opts)
+{
+    GMenu *view_menu, *model;
+    GMenuItem *section;
+    view_menu = g_menu_new();
+
+    model = g_menu_new();
+    section = g_menu_item_new_section(NULL, G_MENU_MODEL(model));
+    g_menu_append_item(view_menu, section);
+#if defined(CONFIG_VTE4)
+    g_menu_append(model, _("_Copy"), "win.copy");
+#endif
+    g_menu_append(model, _("_Fullscreen"), "win.fullscreen");
+
+    model = g_menu_new();
+    section = g_menu_item_new_section(NULL, G_MENU_MODEL(model));
+    g_menu_append_item(view_menu, section);
+
+    g_menu_append(model, _("Zoom _In"), "win.zoom-in");
+    g_menu_append(model, _("Zoom _Out"), "win.zoom-out");
+    g_menu_append(model, _("Best _Fit"), "win.zoom-fixed");
+    g_menu_append(model, _("Zoom To _Fit"), "win.zoom-fit");
+
+    model = g_menu_new();
+    section = g_menu_item_new_section(NULL, G_MENU_MODEL(model));
+    g_menu_append_item(view_menu, section);
+
+    g_menu_append(model, _("Grab On _Hover"),
+                  "win.grab-on-hover");
+    g_menu_append(model, _("_Grab Input"),
+                  "win.grab-input");
+
+    s->vc_menu = g_menu_new();
+    section = g_menu_item_new_section(NULL, G_MENU_MODEL(s->vc_menu));
+    g_menu_append_item(view_menu, section);
+
+    model = g_menu_new();
+    section = g_menu_item_new_section(NULL, G_MENU_MODEL(model));
+    g_menu_append_item(view_menu, section);
+
+    g_menu_append(model, _("Show _Tabs"), "win.show-tabs");
+    g_menu_append(model, _("Detach Tab"), "win.untabify");
+    g_menu_append(model, _("Show Menubar"), "win.show-menubar");
+
+    return view_menu;
+}
+
+/**
+ * Create the menu bar model.
+ */
+static GMenu *
+gd_create_menus_models(GtkDisplayState *s, DisplayOptions *opts)
+{
+    GMenu *model = g_menu_new();
+    GMenuModel *machine_menu = G_MENU_MODEL(gd_create_menu_machine(s));
+    GMenuModel *view_menu = G_MENU_MODEL(gd_create_menu_view(s, opts));
+
+    GMenuItem *machine_item = g_menu_item_new_submenu(_("_Machine"),
+                                                      machine_menu);
+    g_menu_insert_item(model, 0, machine_item);
+
+    GMenuItem *view_menu_item = g_menu_item_new_submenu(_("_View"),
+                                                        view_menu);
+    g_menu_insert_item(model, 1, view_menu_item);
+
+    return model;
+}
+
+static GActionEntry window_entries[] =
+{
+  { "quit", on_quit_cb, NULL, NULL, NULL },
+  { "power_down", on_powerdown_cb, NULL, NULL, NULL },
+  { "pause", on_pause_cb, NULL, "false", NULL },
+  { "reset", on_reset_cb, NULL, NULL, NULL },
+  { "untabify", on_untabify_cb, NULL, NULL, NULL },
+  { "grab-on-hover", NULL, NULL, "false", NULL },
+  { "grab-input", on_grab_input_cb, NULL, "false", NULL },
+  { "show-tabs", on_show_tabs_cb, NULL, "false", NULL },
+  { "fullscreen", on_fullscreen_cb, NULL, NULL, NULL },
+  { "show-menubar", on_show_menubar_cb, NULL, "false", NULL },
+  { "zoom-fit", on_zoom_fit_cb, NULL, "false", NULL },
+  { "zoom-in", on_zoom_in_cb, NULL, NULL, NULL },
+  { "zoom-out", on_zoom_out_cb, NULL, NULL, NULL },
+  { "zoom-fixed", on_zoom_fixed_cb, NULL, NULL, NULL },
+  { "copy", on_copy_cb, NULL, NULL, NULL },
+};
+
+/**
+ * Create the actions and add them to the window.
+ */
+static void 
+setup_actions(GtkDisplayState *ds)
+{
+    GAction *show_menubar_action;
+    GAction *copy_action;
+    VirtualConsole *vc = gd_vc_find_current(ds);
+    GSimpleAction *vc_action = g_simple_action_new_stateful("vc", G_VARIANT_TYPE_STRING,
+                                                            g_variant_new_string(vc->label));
+    g_signal_connect(vc_action, "activate",
+                     G_CALLBACK(on_switch_vc_cb), ds);
+    g_action_map_add_action(G_ACTION_MAP(ds->actions), G_ACTION(vc_action));
+    g_action_map_add_action_entries(G_ACTION_MAP(ds->actions),
+                                    window_entries, G_N_ELEMENTS(window_entries),
+                                    ds);
+
+    gboolean show_menubar = !ds->opts->u.gtk4.has_show_menubar ||
+                            ds->opts->u.gtk4.show_menubar;
+    show_menubar_action = g_action_map_lookup_action(G_ACTION_MAP(ds->actions), "show-menubar");
+    s_action_set_state(G_SIMPLE_ACTION(show_menubar_action), show_menubar);
+
+    /** We disable copy action if it is not a VTE widget at start up */
+    copy_action = g_action_map_lookup_action(G_ACTION_MAP(ds->actions), "copy");
+    g_simple_action_set_enabled(G_SIMPLE_ACTION(copy_action), 
+                                !VIRTUAL_CONSOLE_IS_GFX_WIDGET(vc->widget));
+}
+
+/**
+ * Handle GApplication's startup signal.
+ *
+ * We only set up the keyboard shortcuts here.
+ */
+static void
+on_app_startup(GtkApplication *app, GtkDisplayState *ds)
+{
+    const char *quit_accels[2] = { "<Ctrl><Alt>Q", NULL };
+    const char *fullscreen_accels[2] = { "<Ctrl><Alt>F", NULL };
+    const char *show_menubar_accels[2] = { "<Ctrl><Alt>M", NULL };
+    const char *grab_input_accels[2] = { "<Ctrl><Alt>G", NULL };
+    const char *best_fit_accels[2] = { "<Ctrl><Alt>0", NULL };
+    const char *zoom_out_accels[2] = { "<Ctrl><Alt>minus", NULL };
+    const char *zoom_in_accels[2] = { "<Ctrl><Alt>plus", NULL };
+
+    gtk_application_set_accels_for_action(app, "win.zoom-in",
+                                          zoom_in_accels);
+    gtk_application_set_accels_for_action(app, "win.zoom-out",
+                                          zoom_out_accels);
+    gtk_application_set_accels_for_action(app, "win.zoom-fixed",
+                                          best_fit_accels);
+    gtk_application_set_accels_for_action(app, "win.grab-input",
+                                          grab_input_accels);
+    gtk_application_set_accels_for_action(app, "win.show-menubar",
+                                          show_menubar_accels);
+    gtk_application_set_accels_for_action(app, "win.fullscreen",
+                                          fullscreen_accels);
+    gtk_application_set_accels_for_action(app, "win.quit",
+                                          quit_accels);
+}
+
+/**
+ * Handle GApplication's activate signal.
+ */
+static void
+on_app_activate(GtkApplication *app, GtkDisplayState *ds)
+{
+    VirtualConsole *vc;
+    GtkIconTheme *theme;
+    GMenu *menu;
+    GtkWidget *vbox;
+    QemuConsole *con;
+    int n_vc, i;
+    GdkDisplay *display;
+    char *dir;
+    GAction *action;
+    bool zoom_to_fit = false;
+
+    g_set_prgname("qemu");
+
+    ds->window = gtk_window_new();
+    //gtk_window_set_application(GTK_WINDOW(ds->window), ds->app);
+    ds->actions = g_simple_action_group_new();
+    gtk_widget_insert_action_group(ds->window, "win", G_ACTION_GROUP(ds->actions));
+    gtk_window_set_default_size(GTK_WINDOW(ds->window), 720, 360);
+    vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    ds->notebook = gtk_notebook_new();
+    menu = gd_create_menus_models(ds, ds->opts);
+    ds->menubar = gtk_popover_menu_bar_new_from_model(G_MENU_MODEL(menu));
+    gtk_widget_set_visible(ds->menubar, TRUE);
+
+    display = gtk_widget_get_display(ds->window);
+    theme = gtk_icon_theme_get_for_display(display);
+    dir = get_relocated_path(CONFIG_QEMU_ICONDIR);
+    gtk_icon_theme_add_search_path(theme, dir);
+    g_free(dir);
+
+    if (ds->opts->has_show_cursor && ds->opts->show_cursor) {
+        ds->null_cursor = NULL; /* default pointer */
+    } else {
+        ds->null_cursor = gdk_cursor_new_from_name("none", NULL);
+    }
+
+    gtk_window_set_icon_name(GTK_WINDOW(ds->window), "qemu");
+
+    g_signal_connect(ds->window, "close-request",
+                     G_CALLBACK(gd_window_close), ds);
+    g_signal_connect(ds->notebook, "switch-page",
+                     G_CALLBACK(gd_change_page), ds);
+
+    gtk_notebook_set_show_tabs(GTK_NOTEBOOK(ds->notebook), FALSE);
+    gtk_notebook_set_show_border(GTK_NOTEBOOK(ds->notebook), FALSE);
+
+    gtk_widget_set_vexpand(vbox, TRUE);
+    gtk_box_append(GTK_BOX(vbox), ds->menubar);
+    gtk_box_append(GTK_BOX(vbox), ds->notebook);
+
+    gtk_window_set_child(GTK_WINDOW(ds->window), vbox);
+
+    gtk_window_present(GTK_WINDOW(ds->window));
+    if (ds->opts->u.gtk4.has_show_menubar &&
+        !ds->opts->u.gtk4.show_menubar) {
+        gtk_widget_set_visible(ds->menubar, FALSE);
+    }
+
+    for (n_vc = 0;; n_vc++) {
+        con = qemu_console_lookup_by_index(n_vc);
+        if (!con) {
+            break;
+        }
+        VirtualConsole *vc = &ds->vc[n_vc];
+        vc->index = n_vc;
+        vc->s = ds;
+        virtual_console_gfx_widget_new(vc, con);
+        gd_vc_widget_init(ds, vc);
+        ds->nb_vcs++;
+    }
+#if defined(CONFIG_VTE4)
+    for (i = 0; i < nb_vcs; i++) {
+        VirtualConsole *vc = &ds->vc[ds->nb_vcs];
+        vc->s = ds;
+        vc->index = ds->nb_vcs;
+        virtual_console_vte_widget_new(vc);
+        gd_vc_widget_init(ds, vc);
+        ds->nb_vcs++;
+    }
+#endif
+    setup_actions(ds);
+    
+    vc = gd_vc_find_current(ds);
+
+    gtk_window_set_focus(GTK_WINDOW(ds->window), vc->widget);
+
+    if (ds->opts->has_full_screen &&
+        ds->opts->full_screen) {
+        action = g_action_map_lookup_action(G_ACTION_MAP(ds->actions), "fullscreen");
+        g_action_activate(action, NULL);
+    }
+    if (ds->opts->u.gtk4.has_grab_on_hover &&
+        ds->opts->u.gtk4.grab_on_hover) {
+        action = g_action_map_lookup_action(G_ACTION_MAP(ds->actions), "grab-on-hover");
+        g_action_activate(action, g_variant_new_boolean(TRUE));
+    }
+    if (ds->opts->u.gtk4.has_show_tabs &&
+        ds->opts->u.gtk4.show_tabs) {
+        action = g_action_map_lookup_action(G_ACTION_MAP(ds->actions), "show-tabs");
+        g_action_activate(action, g_variant_new_boolean(TRUE));
+    }
+
+    if (dpy_ui_info_supported(vc->gfx.dcl.con)) {
+        zoom_to_fit = true;
+    }
+    if (ds->opts->u.gtk4.has_zoom_to_fit) {
+        zoom_to_fit = ds->opts->u.gtk4.zoom_to_fit;
+    }
+    if (zoom_to_fit) {
+        action = g_action_map_lookup_action(G_ACTION_MAP(ds->actions), "zoom-fit");
+        g_action_activate(action, NULL);
+    }
+
+    /** We disable show tabs / untabify actions as they are not useful */
+    if (ds->nb_vcs == 1) {
+        action = g_action_map_lookup_action(G_ACTION_MAP(ds->actions), "untabify");
+        g_simple_action_set_enabled(G_SIMPLE_ACTION(action), FALSE);
+
+        action = g_action_map_lookup_action(G_ACTION_MAP(ds->actions), "show-tabs");
+        g_simple_action_set_enabled(G_SIMPLE_ACTION(action), FALSE);
+
+        action = g_action_map_lookup_action(G_ACTION_MAP(ds->actions), "vc");
+        g_simple_action_set_enabled(G_SIMPLE_ACTION(action), FALSE);
+    }
+
+    ds->mouse_mode_notifier.notify = gd_mouse_mode_change;
+    qemu_add_mouse_mode_change_notifier(&ds->mouse_mode_notifier);
+    qemu_add_vm_change_state_handler(on_runstate_change_cb, ds);
+    gd_update_caption(ds);
+}
+
+static void
+gtk_display_init(DisplayState *ds, DisplayOptions *opts)
+{
+    GtkDisplayState *s = g_malloc0(sizeof(*s));
+    char *dir;
+
+    if (!gtkinit) {
+        fprintf(stderr, "gtk initialization failed\n");
+        exit(1);
+    }
+
+    /*
+     * Mostly LC_MESSAGES only. See early_gtk_display_init() for details. For
+     * LC_CTYPE, we need to make sure that non-ASCII characters are considered
+     * printable, but without changing any of the character classes to make
+     * sure that we don't accidentally break implicit assumptions.
+     */
+    setlocale(LC_MESSAGES, "");
+    setlocale(LC_CTYPE, "C.UTF-8");
+    dir = get_relocated_path(CONFIG_QEMU_LOCALEDIR);
+    bindtextdomain("qemu", dir);
+    g_free(dir);
+    bind_textdomain_codeset("qemu", "UTF-8");
+    textdomain("qemu");
+
+    assert(opts->type == DISPLAY_TYPE_GTK4);
+    s->opts = opts;
+    s->app = gtk_application_new("org.qemu.qemu", G_APPLICATION_FLAGS_NONE);
+    g_signal_connect(s->app, "startup",
+                    G_CALLBACK(on_app_startup), s);
+    g_signal_connect(s->app, "activate",
+                    G_CALLBACK(on_app_activate), s);
+    g_application_run(G_APPLICATION(s->app), 0, NULL);
+    /**
+     * Potential problem: stop using GtkApplication as that would potentially create
+     * a new MainLoop which would stop the timer from working
+     * 
+     */
+}
+
+static void
+early_gtk_display_init(DisplayOptions *opts)
+{
+    display_opengl = 1;
+    /*
+     * The QEMU code relies on the assumption that it's always run in
+     * the C locale. Therefore it is not prepared to deal with
+     * operations that produce different results depending on the
+     * locale, such as printf's formatting of decimal numbers, and
+     * possibly others.
+     *
+     * Since GTK calls setlocale() by default -importing the locale
+     * settings from the environment- we must prevent it from doing so
+     * using gtk_disable_setlocale().
+     *
+     * QEMU's GTK UI, however, _does_ have translations for some of
+     * the menu items. As a trade-off between a functionally correct
+     * QEMU and a fully internationalized UI we support importing
+     * LC_MESSAGES from the environment (see the setlocale() call
+     * earlier in this file). This allows us to display translated
+     * messages leaving everything else untouched.
+     */
+    gtk_disable_setlocale();
+    gtkinit = gtk_init_check();
+    if (!gtkinit) {
+        /* don't exit yet, that'll break -help */
+        return;
+    }
+    assert(opts->type == DISPLAY_TYPE_GTK4);
+    assert(opts->gl != DISPLAYGL_MODE_OFF);
+
+    keycode_map = gd_get_keymap(&keycode_maplen);
+#if defined(CONFIG_VTE4)
+    vte_vc_type_register();
+#endif
+}
+
+static QemuDisplay qemu_display_gtk = {
+    .type       = DISPLAY_TYPE_GTK4,
+    .early_init = early_gtk_display_init,
+    .init       = gtk_display_init,
+};
+
+static void
+register_gtk(void)
+{
+    qemu_display_register(&qemu_display_gtk);
+}
+
+type_init(register_gtk);
+
+module_dep("ui-opengl");

--- a/ui/meson.build
+++ b/ui/meson.build
@@ -107,6 +107,14 @@ if gtk.found()
   ui_modules += {'gtk' : gtk_ss}
 endif
 
+if gtk4.found() and not gtk.found()
+  gtk_version = '4.0'
+  glib_version = '2.56'
+  gtk4_ss = ss.source_set()
+  gtk4_ss.add(gtk4, vte4, files('gtk4.c', 'gtk4-gfx-vc.c', 'gtk4-vte-vc.c'))
+  ui_modules += {'gtk4' : gtk4_ss}
+endif
+
 if sdl.found()
   softmmu_ss.add(when: 'CONFIG_WIN32', if_true: files('win32-kbd-hook.c'))
 

--- a/ui/trace-events
+++ b/ui/trace-events
@@ -29,6 +29,17 @@ gd_keymap_windowing(const char *name) "backend=%s"
 gd_gl_area_create_context(void *ctx, int major, int minor) "ctx=%p, major=%d, minor=%d"
 gd_gl_area_destroy_context(void *ctx, void *current_ctx) "ctx=%p, current_ctx=%p"
 
+# gtk4-gfx-vc.c
+# gtk4.c
+gtk4_gd_switch(const char *tab, int width, int height) "tab=%s, width=%d, height=%d"
+gtk4_gd_update(const char *tab, int x, int y, int w, int h) "tab=%s, x=%d, y=%d, w=%d, h=%d"
+gtk4_gd_key_event(const char *tab, int gdk_keycode, int qkeycode, const char *action) "tab=%s, translated GDK keycode %d to QKeyCode %d (%s)"
+gtk4_gd_grab(const char *tab, const char *device, const char *reason) "tab=%s, dev=%s, reason=%s"
+gtk4_gd_ungrab(const char *tab, const char *device) "tab=%s, dev=%s"
+gtk4_gd_keymap_windowing(const char *name) "backend=%s"
+gtk4_gd_gl_area_create_context(void *ctx, int major, int minor) "ctx=%p, major=%d, minor=%d"
+gtk4_gd_gl_area_destroy_context(void *ctx, void *current_ctx) "ctx=%p, current_ctx=%p"
+
 # vnc-auth-sasl.c
 # vnc-auth-vencrypt.c
 # vnc-ws.c


### PR DESCRIPTION
Based on the gtk 3 version

In order to build it, make sure to disable the GTK 3 version as both versions cannot co-exists for now.

Build steps:
```shell
git clone https://github.com/bilelmoussaoui/qemu -b bilelmoussaoui/port-gtk4
cd qemu
mkdir build
cd build
../configure --disable-gtk
make
./qemu-system-x86_64
```